### PR TITLE
Add the ability to change the User-Agent used for API requests.

### DIFF
--- a/censys/base.py
+++ b/censys/base.py
@@ -5,6 +5,8 @@ import unittest
 
 import requests
 
+from . import __name__, __version__
+
 
 class CensysException(Exception):
 
@@ -41,6 +43,7 @@ class CensysAPIBase(object):
 
     DEFAULT_URL = "https://www.censys.io/api/v1"
     DEFAULT_TIMEOUT = 30
+    DEFAULT_USER_AGENT = '%s/%s' % (__name__, __version__)
 
     EXCEPTIONS = {
         403: CensysUnauthorizedException,
@@ -48,7 +51,7 @@ class CensysAPIBase(object):
         429: CensysRateLimitExceededException
     }
 
-    def __init__(self, api_id=None, api_secret=None, url=None, timeout=None):
+    def __init__(self, api_id=None, api_secret=None, url=None, timeout=None, user_agent_identifier=None):
         self.api_id = api_id or os.environ.get("CENSYS_API_ID", None)
         self.api_secret = api_secret or os.environ.get("CENSYS_API_SECRET", None)
         if not self.api_id or not self.api_secret:
@@ -59,7 +62,11 @@ class CensysAPIBase(object):
         self._session = requests.Session()
         self._session.auth = (self.api_id, self.api_secret)
         self._session.timeout = timeout
-        self._session.headers.update({"accept": "application/json, */8"})
+        self._session.headers.update({
+            "accept": "application/json, */8",
+            "User-Agent": ' '.join(
+                [requests.utils.default_user_agent(), user_agent_identifier or self.DEFAULT_USER_AGENT])
+        })
         # test that everything works by requesting the users account information
         self.account()
 


### PR DESCRIPTION
The default User-Agent is changed from `requests/{requests_version}` to `requests/{requests_version} censys/{censys_version}`.

It is also possible to provide `user_agent_identifier` to the constructor of `CensysAPIBase` to set that second member of the User-Agent string, i.e. `requests/{requests_version} {user_agent_identifier}`.

This gives the user the ability to provide Censys with information about their application to perhaps aid in the identification of a misbehaving client. This is currently possible by accessing the `CensysAPIBase._session` object, but providing an official API for this functionality would probably encourage its proper use.

See scolby33/OCSPdash#12.