### PR TITLE
Add certificates bulk endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ endpoints. There is a Python class for each index: `CensysIPv4`,
 `CensysWebsites`, and `CensysCertificates`. 
 
 Below, we show an example for certificates, but the same methods exist for each 
-of the three indices.
+of the three indices, with the exception of bulk which is only supported by the certificates index.
 ```python
 import censys.certificates
 
@@ -34,10 +34,15 @@ c = censys.certificates.CensysCertificates(api_id="XXX", api_secret="XXX")
 # view specific certificate
 print (c.view("a762bf68f167f6fbdf2ab00fdefeb8b96f91335ad6b483b482dfd42c179be076"))
 
+fingerprints = list()
 # iterate over certificates that match a search
 fields = ["parsed.subject_dn", "parsed.fingerprint_sha256"]
 for cert in c.search("github.com and valid_nss: true", fields=fields):
+	fingerprints.append(cert["parsed.fingerprint_sha256"])
 	print (cert["parsed.subject_dn"])
+
+# get certificates in bulk from a list of fingerprints
+print (c.bulk(fingerprints))
 
 # aggregate report on key types used by trusted certificates
 print (c.report(query="valid_nss: true", field="parsed.subject_key_info.key_algorithm.name"))

--- a/censys/certificates.py
+++ b/censys/certificates.py
@@ -10,7 +10,7 @@ class CensysCertificates(CensysIndex):
 
     def __init__(self, *args, **kwargs):
         CensysIndex.__init__(self, *args, **kwargs)
-        self.bulk_path = "/bulk/%s" % self.INDEX_NAME
+        self.bulk_path = "/bulk/{}".format(self.INDEX_NAME)
 
     def bulk(self, fingerprints):
         result = dict()

--- a/censys/certificates.py
+++ b/censys/certificates.py
@@ -6,6 +6,25 @@ from .base import CensysAPIBase, CensysIndex, CensysException
 class CensysCertificates(CensysIndex):
 
     INDEX_NAME = "certificates"
+    MAX_PER_BULK_REQUEST = 50
+
+    def __init__(self, *args, **kwargs):
+        CensysIndex.__init__(self, *args, **kwargs)
+        self.bulk_path = "/bulk/%s" % self.INDEX_NAME
+
+    def bulk(self, fingerprints):
+        result = dict()
+        start = 0
+        end = self.MAX_PER_BULK_REQUEST
+        while start < len(fingerprints):
+            data = {
+                "fingerprints": fingerprints[start:end]
+            }
+            result.update(self._post(self.bulk_path,data=data))
+            start = end
+            end += self.MAX_PER_BULK_REQUEST
+
+        return result
 
 
 class CensysCertificatesTests(unittest.TestCase):
@@ -31,6 +50,12 @@ class CensysCertificatesTests(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertIn("parsed.subject_dn", result[0])
         self.assertIn("parsed.fingerprint_sha256", result[0])
+
+    def testBulk(self):
+        x = self._api.bulk(["fce621c0dc1c666d03d660472f636ce91e66e96460545f0da7eb1a24873e2f70"])
+
+        self.assertEqual(len(x.keys()), 1)
+        self.assertIn("fce621c0dc1c666d03d660472f636ce91e66e96460545f0da7eb1a24873e2f70", x)
 
     # def testMultiplePages(self):
     #     q = "parsed.extensions.basic_constraints.is_ca: true AND parsed.signature.self_signed: false"


### PR DESCRIPTION
## Technical changes
- adds support for bulk endpoint https://censys.io/api/v1/docs/bulk

## How to test
```python
import censys.certificates
import json

c = censys.certificates.CensysCertificates()


fingerprints = list()
# iterate over certificates that match a search
fields = ["parsed.subject_dn", "parsed.fingerprint_sha256"]
for cert in c.search("github.com", fields=fields, max_records=75):
	fingerprints.append(cert["parsed.fingerprint_sha256"])

print (json.dumps(c.bulk(fingerprints)))
```

and run
```
python setup.py test
```