### PR TITLE
fix: fetch subsequent logbook pages correctly

### DIFF
--- a/censys/asm/api.py
+++ b/censys/asm/api.py
@@ -103,6 +103,7 @@ class CensysAsmAPI(CensysAPIBase):
         while not end_of_events:
             res = self._get(path, args=args)
             end_of_events = res["endOfEvents"]
+            args = {"cursor": res["nextCursor"]}
 
             for event in res["events"]:
                 yield event

--- a/censys/asm/events.py
+++ b/censys/asm/events.py
@@ -40,7 +40,7 @@ class Events(CensysAsmAPI):
 
     def get_events(self, cursor: Optional[str] = None) -> Generator[dict, None, None]:
         """
-        Requests a logbook cursor.
+        Requests logbook events from inception or from the provided cursor.
 
         Args:
             cursor (str, optional): Logbook cursor.

--- a/tests/asm/test_events.py
+++ b/tests/asm/test_events.py
@@ -19,6 +19,7 @@ EVENTS_CURSOR_URL = f"{BASE_URL}/logbook-cursor"
 EVENTS_RESOURCE_TYPE = "events"
 
 TEST_CURSOR = "eyJmaWx0ZXIiOnt9LCJzdGFydCI6MH0"
+TEST_NEXT_CURSOR = "eyJmaWx0ZXIiOnt9LCJzdGFydCI6MjA3MTJ9"
 TEST_START_DATE = "2020-10-29T19:26:34.371Z"
 TEST_START_ID = 20712
 
@@ -108,8 +109,11 @@ class EventsUnitTests(CensysAsmTestCase):
         res = [event for event in events]
 
         self.assertEqual(RESOURCE_PAGING_RESULTS, res)
-        mock.assert_called_with(
+        mock.assert_any_call(
             EVENTS_URL, params={"cursor": None}, timeout=TEST_TIMEOUT
+        )
+        mock.assert_any_call(
+            EVENTS_URL, params={"cursor": TEST_NEXT_CURSOR}, timeout=TEST_TIMEOUT
         )
 
     @patch("censys.base.requests.Session.get")
@@ -119,8 +123,11 @@ class EventsUnitTests(CensysAsmTestCase):
         res = [event for event in events]
 
         self.assertEqual(RESOURCE_PAGING_RESULTS, res)
-        mock.assert_called_with(
+        mock.assert_any_call(
             EVENTS_URL, params={"cursor": TEST_CURSOR}, timeout=TEST_TIMEOUT
+        )
+        mock.assert_any_call(
+            EVENTS_URL, params={"cursor": TEST_NEXT_CURSOR}, timeout=TEST_TIMEOUT
         )
 
 

--- a/tests/asm/utils.py
+++ b/tests/asm/utils.py
@@ -40,7 +40,8 @@ class MockResponse:
             resource_type: self.get_resource(),  # Return dummy resource generator
             "pageNumber": 1,
             "totalPages": 3,  # Default to 3 pages of resources
-            "cursor": "eyJmaWx0ZXIiOnt9LCJzdGFydCI6MjA3MTJ9",
+            "nextCursor": "eyJmaWx0ZXIiOnt9LCJzdGFydCI6MjA3MTJ9",
+            "cursor": "eyJmaWx0ZXIiOnt9LCJzdGFydCI6MH0",
             "endOfEvents": False,
         }
 


### PR DESCRIPTION
ASM's `_get_logbook_page()` function was not correctly updating the nextCursor value when fetching the next page of logbook events. This led to the API endlessly refetching the same initial page of logbook events. This change corrects that issue by setting the nextCursor value at the end of the for loop to the cursor representing the next page of results.