### PR TITLE
View All Method

### DIFF
--- a/examples/v2/search_hosts.py
+++ b/examples/v2/search_hosts.py
@@ -1,4 +1,6 @@
 """Search hosts data set."""
+from pprint import pprint
+
 from censys.search import SearchClient
 
 c = SearchClient()
@@ -11,3 +13,7 @@ print(query())
 query = c.v2.hosts.search("service.service_name: HTTP", per_page=5, pages=2)
 for page in query:
     print(page)
+
+# View all results
+query = c.v2.hosts.search("service.service_name: HTTP", per_page=5, pages=2)
+pprint(query.view_all())

--- a/tests/asm/test_api.py
+++ b/tests/asm/test_api.py
@@ -82,7 +82,3 @@ class CensysAsmAPITests(CensysTestCase):
         res = list(self.api._get_page(f"/{keyword}"))
 
         assert res == page_json[keyword] + second_page
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/asm/test_assets.py
+++ b/tests/asm/test_assets.py
@@ -209,7 +209,3 @@ class AssetsUnitTest(unittest.TestCase):
             params={"pageNumber": 3, "pageSize": 500},
             timeout=TEST_TIMEOUT,
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/asm/test_events.py
+++ b/tests/asm/test_events.py
@@ -123,7 +123,3 @@ class EventsUnitTests(unittest.TestCase):
         mock.assert_any_call(
             EVENTS_URL, params={"cursor": TEST_NEXT_CURSOR}, timeout=TEST_TIMEOUT
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/asm/test_seeds.py
+++ b/tests/asm/test_seeds.py
@@ -139,7 +139,3 @@ class SeedsUnitTests(unittest.TestCase):
         mock.assert_called_with(
             f"{SEEDS_URL}/{TEST_SEED_ID}", params={}, timeout=TEST_TIMEOUT
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,5 +1,4 @@
 import contextlib
-import unittest
 from io import StringIO
 from unittest.mock import patch
 
@@ -38,7 +37,3 @@ class CensysCliTest(CensysTestCase):
             cli_main()
 
         assert __version__ in temp_stdout.getvalue()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/cli/test_search.py
+++ b/tests/cli/test_search.py
@@ -374,9 +374,3 @@ class CensysCliSearchTest(CensysTestCase):
             match="The CSV file format is not valid for Search 2.0 responses.",
         ):
             cli_main()
-
-
-if __name__ == "__main__":
-    import unittest
-
-    unittest.main()

--- a/tests/cli/test_view.py
+++ b/tests/cli/test_view.py
@@ -179,9 +179,3 @@ class CensysCliSearchTest(CensysTestCase):
 
         # Cleanup
         os.remove(json_path)
-
-
-if __name__ == "__main__":
-    import unittest
-
-    unittest.main()

--- a/tests/search/v1/test_api.py
+++ b/tests/search/v1/test_api.py
@@ -77,7 +77,3 @@ class CensysAPIBaseTestsNoSearchEnv(unittest.TestCase):
             CensysException, match="No API ID or API secret configured."
         ):
             CensysSearchAPI()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/search/v1/test_certificates.py
+++ b/tests/search/v1/test_certificates.py
@@ -1,5 +1,3 @@
-import unittest
-
 import responses
 
 from tests.utils import CensysTestCase
@@ -35,7 +33,3 @@ class CensysCertificatesTests(CensysTestCase):
         )
 
         assert res == BULK_JSON
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/search/v1/test_data.py
+++ b/tests/search/v1/test_data.py
@@ -1,5 +1,3 @@
-import unittest
-
 import responses
 
 from tests.utils import CensysTestCase
@@ -60,7 +58,3 @@ class CensysDataTest(CensysTestCase):
         res = self.api.view_result(SERIES, RESULT)
 
         assert res == RESULT_JSON
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/search/v1/test_indexes.py
+++ b/tests/search/v1/test_indexes.py
@@ -1,5 +1,3 @@
-import unittest
-
 import pytest
 import responses
 from parameterized import parameterized_class
@@ -135,7 +133,3 @@ class CensysIndexTests(CensysTestCase):
 
         res = list(self.api.search("*", max_records=MAX_RECORDS))
         assert len(res) == MAX_RECORDS
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/search/v2/test_api.py
+++ b/tests/search/v2/test_api.py
@@ -37,7 +37,3 @@ class CensysAPIBaseTestsNoSearchEnv(unittest.TestCase):
             CensysException, match="No API ID or API secret configured."
         ):
             CensysSearchAPIv2()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/search/v2/test_hosts.py
+++ b/tests/search/v2/test_hosts.py
@@ -238,9 +238,3 @@ class TestHosts(CensysTestCase):
         query = self.api.search("service.service_name: HTTP", per_page=test_per_page)
         results = query.view_all()
         assert results == expected
-
-
-if __name__ == "__main__":
-    import unittest
-
-    unittest.main()


### PR DESCRIPTION
Closes #95

- Added `view_all` method to the query class
- Removed `unittest.main()` from tests

See an example [here](https://github.com/censys/censys-python/blob/963be3c2a4003f90ba43c25b62064ad3e77713b9/examples/v2/search_hosts.py#L18).