### PR TITLE
feat(api): Added Host Diff API

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,6 @@
 [run]
-include = censys/*
+include =
+    censys/*
+
+[report]
+show_missing = true

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,2 @@
 [run]
-include = 
-    censys/*
+include = censys/*

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 88
-exclude = 
+exclude =
     docs,
     .venv,
     # No need to traverse our git directory
@@ -11,7 +11,7 @@ exclude =
     build,
     # This contains builds of flake8 that we don't want to check
     dist
-per-file-ignores = 
+per-file-ignores =
     tests/*.py:E501,D100,D101,D102,D103,D104,D107,
     __init__.py:F401,F403,
     censys/search/v2/certs.py:DAR101

--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,8 @@ dmypy.json
 .vscode/
 .idea/
 
-# pre-commit
+# Config
+*.cfg
 .pre-commit-config.yaml
 
 # Output

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,10 @@ dmypy.json
 
 # IDE
 .vscode/
+.idea/
+
+# pre-commit
+.pre-commit-config.yaml
 
 # Output
 censys-query-output.*

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Successfully authenticated
 - [Documentation](https://censys-python.rtfd.io)
 - [Discussions](https://github.com/censys/censys-python/discussions)
 - [Censys Homepage](https://censys.io/)
+- [Censys Search](https://search.censys.io/)
 
 ## Contributing
 

--- a/censys/cli/__init__.py
+++ b/censys/cli/__init__.py
@@ -19,7 +19,8 @@ def main():
 
     try:
         args.func(args)
-    except AttributeError:
+    except AttributeError as e:
+        print(str(e))
         parser.print_help()
         parser.exit()
     except KeyboardInterrupt:  # pragma: no cover

--- a/censys/cli/__init__.py
+++ b/censys/cli/__init__.py
@@ -19,10 +19,6 @@ def main():
 
     try:
         args.func(args)
-    except AttributeError as e:
-        print(str(e))
-        parser.print_help()
-        parser.exit()
     except KeyboardInterrupt:  # pragma: no cover
         sys.exit(1)
 

--- a/censys/cli/args.py
+++ b/censys/cli/args.py
@@ -46,7 +46,13 @@ def get_parser() -> argparse.ArgumentParser:
         default=False,
         help="display version",
     )
-    parser.set_defaults()
+
+    def print_help(_: argparse.Namespace):
+        """Prints help."""
+        parser.print_help()
+        parser.exit()
+
+    parser.set_defaults(func=print_help)
 
     subparsers = parser.add_subparsers()
 

--- a/censys/cli/commands/__init__.py
+++ b/censys/cli/commands/__init__.py
@@ -1,4 +1,4 @@
 """Censys CLI commands."""
 from . import account, asm, config, hnri, search, view
 
-__all__ = ["asm", "config", "hnri", "search", "view", "account"]
+__all__ = ["account", "asm", "config", "hnri", "search", "view"]

--- a/censys/cli/commands/asm.py
+++ b/censys/cli/commands/asm.py
@@ -60,7 +60,7 @@ def cli_add_seeds(args: argparse.Namespace):
         if args.input_file == "-":
             data = sys.stdin.read()
         else:
-            with open(args.input_file, "r") as f:
+            with open(args.input_file) as f:
                 data = f.read()
     else:
         data = args.json

--- a/censys/cli/commands/config.py
+++ b/censys/cli/commands/config.py
@@ -60,16 +60,23 @@ def cli_config(_: argparse.Namespace):  # pragma: no cover
         client = CensysSearchAPIv2(api_id, api_secret)
         account = client.account()
         email = account.get("email")
+        console.print(f"\nSuccessfully authenticated for {email}")
 
         # Assumes that login was successfully
         config.set(DEFAULT, "api_id", api_id)
         config.set(DEFAULT, "api_secret", api_secret)
 
         write_config(config)
-        console.print(f"\nSuccessfully authenticated for {email}")
         sys.exit(0)
     except CensysUnauthorizedException:
         console.print("Failed to authenticate")
+        sys.exit(1)
+    except PermissionError as e:
+        console.print(e)
+        console.print(
+            "Cannot write config file to directory. "
+            + "Please set the `CENSYS_CONFIG_PATH` environmental variable to a writeable location."
+        )
         sys.exit(1)
 
 

--- a/censys/cli/commands/hnri.py
+++ b/censys/cli/commands/hnri.py
@@ -166,6 +166,7 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
         parents=[parents["auth"]],
     )
     hnri_parser.add_argument(
+        "-O",
         "--open",
         action="store_true",
         help="open your IP in browser",

--- a/censys/cli/commands/search.py
+++ b/censys/cli/commands/search.py
@@ -9,7 +9,6 @@ from censys.cli.utils import INDEXES, V1_INDEXES, V2_INDEXES, err_console, write
 from censys.common.exceptions import CensysCLIException
 from censys.search import SearchClient
 
-Fields = List[str]
 Results = List[dict]
 
 DEFAULT_FIELDS = {
@@ -72,7 +71,7 @@ def cli_search(args: argparse.Namespace):
         if args.max_records:
             search_args["max_records"] = args.max_records
 
-        fields: Fields = []
+        fields: List[str] = []
         if args.fields:
             if args.overwrite:
                 fields = args.fields

--- a/censys/cli/commands/search.py
+++ b/censys/cli/commands/search.py
@@ -171,6 +171,7 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
         help="output file path",
     )
     search_parser.add_argument(
+        "-O",
         "--open",
         action="store_true",
         help="open query in browser",

--- a/censys/cli/commands/view.py
+++ b/censys/cli/commands/view.py
@@ -67,7 +67,7 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
     view_parser.add_argument(
         "document_id",
         type=str,
-        help="a string written in Censys Search syntax",
+        help="a document id (IP address) to view",
     )
     view_parser.add_argument(
         "--index-type",
@@ -90,6 +90,7 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
         help="json output file path",
     )
     view_parser.add_argument(
+        "-O",
         "--open",
         action="store_true",
         help="open document in browser",

--- a/censys/cli/utils.py
+++ b/censys/cli/utils.py
@@ -12,7 +12,6 @@ from rich.console import Console
 from censys.common.config import DEFAULT, get_config
 from censys.common.deprecation import DeprecationDecorator
 
-Fields = List[str]
 Results = Union[List[dict], Dict[str, Any]]
 
 V1_INDEXES = ["certs"]
@@ -37,13 +36,13 @@ def print_wrote_file(file_path: str):
 
 
 @DeprecationDecorator("CSV output is deprecated and will be removed in the future.")
-def _write_csv(file_path: str, search_results: Results, fields: Fields):
+def _write_csv(file_path: str, search_results: Results, fields: List[str]):
     """Write search results to a new file in CSV format.
 
     Args:
         file_path (str): Name of the file to write to on the disk.
         search_results (Results): A list of results from the query.
-        fields (Fields): A list of fields to write as headers.
+        fields (List[str]): A list of fields to write as headers.
     """
     with open(file_path, "w") as output_file:
         if search_results and isinstance(search_results, list):
@@ -90,7 +89,7 @@ def write_file(
     file_format: str = "screen",
     file_path: Optional[str] = None,
     base_name: str = "censys-query-output",
-    csv_fields: Fields = [],
+    csv_fields: List[str] = [],
 ):
     """Maps formats and writes results.
 
@@ -99,7 +98,7 @@ def write_file(
         file_format (str): Optional; The format of the output.
         file_path (str): Optional; A path to write results to.
         base_name (str): Optional; The base name of the output file.
-        csv_fields (Fields): Optional; A list of fields to write to CSV.
+        csv_fields (List[str]): Optional; A list of fields to write to CSV.
     """
     if file_format and isinstance(file_format, str):
         file_format = file_format.lower()

--- a/censys/common/base.py
+++ b/censys/common/base.py
@@ -3,7 +3,7 @@ import json
 import os
 import warnings
 from functools import wraps
-from typing import Any, Callable, List, Optional, Type
+from typing import Any, Callable, Optional, Type
 
 import backoff
 import requests
@@ -13,12 +13,9 @@ from .exceptions import (
     CensysAPIException,
     CensysException,
     CensysJSONDecodeException,
-    CensysRateLimitExceededException,
     CensysTooManyRequestsException,
 )
 from .version import __version__
-
-Fields = Optional[List[str]]
 
 
 # Wrapper to make max_retries configurable at runtime
@@ -28,7 +25,6 @@ def _backoff_wrapper(method: Callable):
         @backoff.on_exception(
             backoff.expo,
             (
-                CensysRateLimitExceededException,
                 CensysTooManyRequestsException,
                 requests.exceptions.Timeout,
             ),
@@ -50,7 +46,7 @@ class CensysAPIBase:
     """Default API timeout."""
     DEFAULT_USER_AGENT: str = f"censys/{__version__}"
     """Default API user agent."""
-    DEFAULT_MAX_RETRIES: int = 10
+    DEFAULT_MAX_RETRIES: int = 5
     """Default max number of API retries."""
 
     def __init__(

--- a/censys/common/config.py
+++ b/censys/common/config.py
@@ -55,24 +55,8 @@ def get_config() -> configparser.ConfigParser:
     Returns:
         configparser.ConfigParser: Config for Censys.
     """
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(defaults=default_config, default_section=DEFAULT)
     config_path = get_config_path()
-    if not os.path.isfile(config_path):
-        config[DEFAULT] = default_config
-    else:
+    if os.path.isfile(config_path):
         config.read(config_path)
-    check_config(config)
     return config
-
-
-def check_config(config: configparser.ConfigParser):
-    """Checks config against default config for fields.
-
-    Args:
-        config (configparser.ConfigParser): Configuration to write.
-    """
-    for key in default_config:
-        try:
-            config.get(DEFAULT, key)
-        except configparser.NoOptionError:
-            config.set(DEFAULT, key, default_config.get(key))

--- a/censys/search/v2/hosts.py
+++ b/censys/search/v2/hosts.py
@@ -101,20 +101,49 @@ class CensysHosts(CensysSearchAPIv2):
             kwargs["virtual_hosts"] = virtual_hosts
         return super().search(query, per_page, cursor, pages, **kwargs)
 
-    def view_host_names(self, ip_address: str) -> List[str]:
+    def view_host_names(self, ip: str) -> List[str]:
         """Fetches a list of host names for the specified IP address.
 
         Args:
-            ip_address (str): The IP address of the requested host.
+            ip (str): The IP address of the requested host.
 
         Returns:
             List[str]: A list of host names.
         """
-        return self._get(self.view_path + ip_address + "/names")["result"]["names"]
+        return self._get(self.view_path + ip + "/names")["result"]["names"]
+
+    def view_host_diff(
+        self,
+        ip: str,
+        ip_b: Optional[str] = None,
+        at_time: Optional[Datetime] = None,
+        at_time_b: Optional[Datetime] = None,
+    ):
+        """Fetches a diff of the specified IP address.
+
+        Args:
+            ip (str): The IP address of the requested host.
+            ip_b (str): Optional; The IP address of the second host.
+            at_time (Datetime): Optional; An RFC3339 timestamp which represents
+                the point-in-time used as the basis for Host A.
+            at_time_b (Datetime): Optional; An RFC3339 timestamp which represents
+                the point-in-time used as the basis for Host B.
+
+        Returns:
+            dict: A diff of the hosts.
+        """
+        args = {}
+        if ip_b:
+            args["ip_b"] = ip_b
+        if at_time:
+            args["at_time"] = format_rfc3339(at_time)
+        if at_time_b:
+            args["at_time_b"] = format_rfc3339(at_time_b)
+        return self._get(self.view_path + ip + "/diff", args)["result"]
 
     def view_host_events(
         self,
-        ip_address: str,
+        ip: str,
         start_time: Optional[Datetime] = None,
         end_time: Optional[Datetime] = None,
         per_page: Optional[int] = None,
@@ -124,7 +153,7 @@ class CensysHosts(CensysSearchAPIv2):
         """Fetches a list of events for the specified IP address.
 
         Args:
-            ip_address (str): The IP address of the requested host.
+            ip (str): The IP address of the requested host.
             start_time (Datetime): Optional; An RFC3339 timestamp which represents
                 the beginning chronological point-in-time (inclusive) from which events are returned.
             end_time (Datetime): Optional; An RFC3339 timestamp which represents
@@ -144,9 +173,9 @@ class CensysHosts(CensysSearchAPIv2):
         if end_time:
             args["end_time"] = format_rfc3339(end_time)
 
-        return self._get(
-            f"/v2/experimental/{self.INDEX_NAME}/{ip_address}/events", args
-        )["result"]["events"]
+        return self._get(f"/v2/experimental/{self.INDEX_NAME}/{ip}/events", args)[
+            "result"
+        ]["events"]
 
     def list_hosts_with_tag(self, tag_id: str) -> List[str]:
         """Returns a list of hosts which are tagged with the specified tag.

--- a/docs/censys.common.rst
+++ b/docs/censys.common.rst
@@ -49,7 +49,7 @@ censys.common.exceptions module
 
 censys.common.deprecation module
 --------------------------------
-   
+
 .. automodule:: censys.common.deprecation
    :members:
    :undoc-members:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,4 +1,4 @@
-Contributing 
+Contributing
 ============
 
 All contributions (no matter how small) are always welcome.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,4 +1,4 @@
-Development 
+Development
 ===========
 
 Clone the repository:
@@ -14,13 +14,13 @@ Clone the repository:
    .. tab:: HTTPS
 
       .. prompt:: bash $
-      
+
         git clone https://github.com/censys/censys-python.git
-   
+
    .. tab:: GitHub CLI
 
       .. prompt:: bash $
-      
+
         gh repo clone censys/censys-python
 
 Install dependencies via ``pip``:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,11 +28,11 @@ The User Guide
    :maxdepth: 1
 
    quick-start
+   usage-cli
    usage-v2
    usage-v1
    usage-asm
    advanced-usage
-   usage-cli
 
 The API Documentation
 ---------------------

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -1,4 +1,4 @@
-Quick Start 
+Quick Start
 ===========
 
 Assuming you have Python already, install the package:
@@ -42,7 +42,7 @@ Configure your credentials:
    .. tab:: ASM API
 
       .. prompt:: bash
-      
+
          censys asm config
 
       Or you can set the environment variables:

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -30,8 +30,25 @@ Configure your credentials:
 
          censys config
 
+      Or you can set the environment variables:
+
+      .. prompt:: bash
+
+         export CENSYS_API_ID=<your-api-id>
+         export CENSYS_API_SECRET=<your-api-secret>
+
+      Find your credentials on the `Account page <https://search.censys.io/account/api>`_.
+
    .. tab:: ASM API
 
       .. prompt:: bash
       
          censys asm config
+
+      Or you can set the environment variables:
+
+      .. prompt:: bash
+
+         export CENSYS_ASM_API_KEY=<your-api-key>
+
+      Find your credentials on the `Integrations page <https://app.censys.io/integrations>`_.

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -5,13 +5,16 @@ Assuming you have Python already, install the package:
 
 .. tabs::
 
-   .. tab:: from PyPi
+   .. tab:: pip
 
       .. prompt:: bash
 
          pip install censys
 
-   .. tab:: from Kali Linux
+
+      If you do not have pip installed, get it `here <https://pip.pypa.io/en/stable/installation/>`_.
+
+   .. tab:: on Kali Linux
 
       .. prompt:: bash
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,4 +1,4 @@
-Testing 
+Testing
 =======
 
 Testing is done using `pytest <https://docs.pytest.org/en/stable/>`__.

--- a/docs/usage-asm.rst
+++ b/docs/usage-asm.rst
@@ -256,4 +256,3 @@ Below we show how to initialize the AsmClient class object as well as a couple e
     # Get all events
     events = client.events.get_events()
     print(next(events))
-

--- a/docs/usage-asm.rst
+++ b/docs/usage-asm.rst
@@ -45,7 +45,7 @@ Below we show examples for **listing seeds** from the Censys ASM platform.
 
     # Get a specific type of seed. Optional seed types are ["IP_ADDRESS", "DOMAIN_NAME", "CIDR", "ASN"]
     # Here we get IP address seeds.
-    seeds = s.get_seeds('IP_ADDRESS')
+    seeds = s.get_seeds("IP_ADDRESS")
     print(seeds)
 
     # Get a single seed by its ID (here we get seed with ID=3)
@@ -64,17 +64,14 @@ Below we show examples for **adding seeds** to the Censys ASM platform.
     # Here, we add two ASN seeds.
     seed_list = [
         {"type": "ASN", "value": 99998, "label": "seed-test-label"},
-        {"type": "ASN", "value": 99999, "label": "seed-test-label"}
+        {"type": "ASN", "value": 99999, "label": "seed-test-label"},
     ]
     s.add_seeds(seed_list)
 
     # Add a list of seeds, replacing existing seeds with a specified label
     # Here, all seeds with label="seed-test-label" will be removed and then
     # Seeds 99996 and 99997 will be added.
-        seed_list = [
-        {"type": "ASN", "value": 99996},
-        {"type": "ASN", "value": 99997}
-    ]
+    seed_list = [{"type": "ASN", "value": 99996}, {"type": "ASN", "value": 99997}]
     s.replace_seeds_by_label("seed-test-label", seed_list)
 
 Below we show examples for **deleting seeds** from the Censys ASM platform.

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -15,13 +15,13 @@ Below we show an example of Searching from the CLI.
 
 .. prompt:: bash
 
-    censys search 'services.http.response.html_title: "Tesla Energy Powerpack"' --index-type hosts
+    censys search 'services.http.response.html_title: "Dashboard"'
 
 By combining the ``search`` command with ``jq`` we can easily manipulate the output to get the desired fields.
 
 .. prompt:: bash
 
-    censys search 'services.service_name: IKETTLE' --index-type hosts | jq -c '.[] | {ip: .ip}'
+    censys search 'services.service_name: ELASTICSEARCH' | jq -c '.[] | {ip: .ip}'
 
 By setting the ``--pages`` flag to ``-1`` we can get all pages of results.
 
@@ -30,7 +30,7 @@ By setting the ``--pages`` flag to ``-1`` we can get all pages of results.
     censys search 'ip: 8.8.8.0/16' --pages -1 | jq -c '[.[] | .ip]'
 
 ``view``
-----------
+--------
 
 Below we show an example of Viewing a host from the CLI.
 

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -7,6 +7,12 @@ Before continuing please ensure you have successfully configured your credential
 
     censys config
 
+The configuration file by default is writen to ``~/.config/censys/censys.cfg``, but you can change this by setting the ``CENSYS_CONFIG_PATH`` environment variable.
+
+.. prompt:: bash
+
+    export CENSYS_CONFIG_PATH=/path/to/config/file
+
 
 ``search``
 ----------

--- a/docs/usage-v1.rst
+++ b/docs/usage-v1.rst
@@ -31,8 +31,7 @@ Below we show an example using the :attr:`CensysCertificates <censys.search.v1.C
     c = CensysCertificates()
 
     for page in c.search(
-        "validation.nss.valid: true and validation.nss.type: intermediate", 
-        max_records=10
+        "validation.nss.valid: true and validation.nss.type: intermediate", max_records=10
     ):
         print(page)
 
@@ -49,10 +48,10 @@ Below we show an example using the :attr:`CensysCertificates <censys.search.v1.C
     ]
 
     for page in c.search(
-            "censys.io and tags: trusted",
-            fields,
-            max_records=10,
-        ):
+        "censys.io and tags: trusted",
+        fields,
+        max_records=10,
+    ):
         print(page)
 
 ``view``
@@ -139,7 +138,7 @@ Below we show an example using the :attr:`CensysCertificates <censys.search.v1.C
 
     fingerprints = [
         "fce621c0dc1c666d03d660472f636ce91e66e96460545f0da7eb1a24873e2f70",
-        "a762bf68f167f6fbdf2ab00fdefeb8b96f91335ad6b483b482dfd42c179be076"
+        "a762bf68f167f6fbdf2ab00fdefeb8b96f91335ad6b483b482dfd42c179be076",
     ]
 
     # Get bulk certificate data

--- a/docs/usage-v2.rst
+++ b/docs/usage-v2.rst
@@ -17,7 +17,7 @@ Python class objects must be initialized for each resource index (Hosts).
 
 .. note::
 
-   Please note that the Censys Search v2 API does not support searching, viewing, or aggregating the Certificates index. Please use the :attr:`CensysCertificates (v1) <censys.search.v1.CensysCertificates>` for this functionality.
+   Please note that the Censys Search v2 API does not support searching, viewing, or aggregating the Certificates index. Please use the :ref:`CensysCertificates (v1) index <usage-v1:Usage v1>` for this functionality.
 
 
 ``search``
@@ -27,6 +27,7 @@ Below we show an example using the :attr:`CensysHosts <censys.search.v2.CensysHo
 
 .. code:: python
 
+    #!/usr/bin/env python3
     from censys.search import CensysHosts
 
     h = CensysHosts()
@@ -73,6 +74,7 @@ Below we show an example using the :attr:`CensysHosts <censys.search.v2.CensysHo
 
     # You can also pass in a date or datetime object.
     from datetime import date
+
     host = h.view("8.8.8.8", at_time=date(2021, 3, 1))
     print(host)
 
@@ -129,7 +131,7 @@ Below we show an example using the :attr:`CensysHosts <censys.search.v2.CensysHo
     # Fetch a list of host names for the specified IP address.
     names = h.view_host_names("1.1.1.1")
     print(names)
-    
+
 ``view_host_events``
 --------------------
 
@@ -149,8 +151,45 @@ Below we show an example using the :attr:`CensysHosts <censys.search.v2.CensysHo
 
     # You can also pass in a date or datetime objects.
     from datetime import date
-    events = h.view_host_events("1.1.1.1", start_time=date(2021, 7, 1), end_time=date(2021, 7, 31))
+
+    events = h.view_host_events(
+        "1.1.1.1", start_time=date(2021, 7, 1), end_time=date(2021, 7, 31)
+    )
     print(events)
+
+``view_host_diff``
+------------------
+
+**Please note this method is only available only for the CensysHosts index**
+
+Below we show an example using the :attr:`CensysHosts <censys.search.v2.CensysHosts>` index.
+
+.. code:: python
+
+    from censys.search import CensysHosts
+
+    h = CensysHosts()
+
+    # Compare a single host between two timestamps
+    diff = c.view_host_diff("1.1.1.1", at_time=date(2022, 1, 1), at_time_b=date(2022, 1, 2))
+    print(diff)
+
+    # Compare a single host between its current timestamp and a timestamp
+    diff = c.view_host_diff("1.1.1.2", at_time=date(2022, 1, 2))
+    print(diff)
+
+    # Compare two hosts
+    diff = c.view_host_diff("1.1.1.1", ip_b="1.1.1.2")
+    print(diff)
+
+    # Compare two hosts between two timestamps
+    diff = c.view_host_diff(
+        "1.1.1.1",
+        ip_b="1.1.1.2",
+        at_time=date(2022, 1, 1),
+        at_time_b=date(2022, 1, 2),
+    )
+    print(diff)
 
 ``get_hosts_by_cert``
 ---------------------
@@ -166,7 +205,9 @@ Below we show an example using the :attr:`CensysCerts <censys.search.v2.CensysCe
     c = CensysCerts()
 
     # Fetch a list of events for the specified IP address.
-    hosts, links = c.get_hosts_by_cert("fb444eb8e68437bae06232b9f5091bccff62a768ca09e92eb5c9c2cf9d17c426")
+    hosts, links = c.get_hosts_by_cert(
+        "fb444eb8e68437bae06232b9f5091bccff62a768ca09e92eb5c9c2cf9d17c426"
+    )
     print(hosts)
 
 Comments
@@ -184,7 +225,9 @@ Below we show an example using the :attr:`CensysCerts <censys.search.v2.CensysCe
     c = CensysCerts()
 
     # Fetch a list of comments for the specified certificate.
-    comments = c.get_comments("fb444eb8e68437bae06232b9f5091bccff62a768ca09e92eb5c9c2cf9d17c426")
+    comments = c.get_comments(
+        "fb444eb8e68437bae06232b9f5091bccff62a768ca09e92eb5c9c2cf9d17c426"
+    )
     print(comments)
 
 ``add_comment``
@@ -228,7 +271,9 @@ Below we show an example using the :attr:`CensysCerts <censys.search.v2.CensysCe
     c = CensysCerts()
 
     # Delete a comment for a certificate.
-    c.delete_comment("fb444eb8e68437bae06232b9f5091bccff62a768ca09e92eb5c9c2cf9d17c426", 102)
+    c.delete_comment(
+        "fb444eb8e68437bae06232b9f5091bccff62a768ca09e92eb5c9c2cf9d17c426", 102
+    )
 
 Tags
 ----
@@ -313,7 +358,7 @@ Below we show an example using the :attr:`CensysHosts <censys.search.v2.CensysHo
     h = CensysHosts()
 
     # Delete a tag.
-    h.delete_tag("123)
+    h.delete_tag("123")
 
 ``list_tags_on_document``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -327,7 +372,9 @@ Below we show an example using the :attr:`CensysCerts <censys.search.v2.CensysCe
     c = CensysCerts()
 
     # Fetch a list of tags for a document.
-    tags = c.list_tags_on_document("fb444eb8e68437bae06232b9f5091bccff62a768ca09e92eb5c9c2cf9d17c426")
+    tags = c.list_tags_on_document(
+        "fb444eb8e68437bae06232b9f5091bccff62a768ca09e92eb5c9c2cf9d17c426"
+    )
     print(tags)
 
 ``add_tag_to_document``
@@ -342,7 +389,7 @@ Below we show an example using the :attr:`CensysHosts <censys.search.v2.CensysHo
     h = CensysHosts()
 
     # Add a tag to a document.
-    h.add_tag_to_document("123)
+    h.add_tag_to_document("123")
 
 ``remove_tag_from_document``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -356,7 +403,9 @@ Below we show an example using the :attr:`CensysCerts <censys.search.v2.CensysCe
     c = CensysCerts()
 
     # Remove a tag from a document.
-    c.remove_tag_from_document("fb444eb8e68437bae06232b9f5091bccff62a768ca09e92eb5c9c2cf9d17c426")
+    c.remove_tag_from_document(
+        "fb444eb8e68437bae06232b9f5091bccff62a768ca09e92eb5c9c2cf9d17c426"
+    )
 
 ``list_certs_with_tag``
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/search/view_host_diff.py
+++ b/examples/search/view_host_diff.py
@@ -1,0 +1,27 @@
+"""View Host Diff."""
+from datetime import date
+
+from censys.search import CensysHosts
+
+c = CensysHosts()
+
+# Compare a single host between two timestamps
+diff = c.view_host_diff("1.1.1.1", at_time=date(2022, 1, 1), at_time_b=date(2022, 1, 2))
+print(diff)
+
+# Compare a single host between its current timestamp and a timestamp
+diff = c.view_host_diff("1.1.1.2", at_time=date(2022, 1, 2))
+print(diff)
+
+# Compare two hosts
+diff = c.view_host_diff("1.1.1.1", ip_b="1.1.1.2")
+print(diff)
+
+# Compare two hosts between two timestamps
+diff = c.view_host_diff(
+    "1.1.1.1",
+    ip_b="1.1.1.2",
+    at_time=date(2022, 1, 1),
+    at_time_b=date(2022, 1, 2),
+)
+print(diff)

--- a/poetry.lock
+++ b/poetry.lock
@@ -329,17 +329,17 @@ python-versions = "*"
 
 [[package]]
 name = "mypy"
-version = "0.920"
+version = "0.931"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-mypy-extensions = ">=0.4.3,<0.5.0"
-tomli = ">=1.1.0,<3.0.0"
+mypy-extensions = ">=0.4.3"
+tomli = ">=1.1.0"
 typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
-typing-extensions = ">=3.7.4"
+typing-extensions = ">=3.10"
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
@@ -547,7 +547,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "responses"
-version = "0.16.0"
+version = "0.17.0"
 description = "A utility library for mocking out the `requests` Python library."
 category = "dev"
 optional = false
@@ -642,7 +642,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "types-requests"
-version = "2.27.5"
+version = "2.27.6"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -653,7 +653,7 @@ types-urllib3 = "<1.27"
 
 [[package]]
 name = "types-urllib3"
-version = "1.26.4"
+version = "1.26.6"
 description = "Typing stubs for urllib3"
 category = "dev"
 optional = false
@@ -695,7 +695,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2,<4.0"
-content-hash = "9088014c936470e2143d588c1ca1ac503efc5631e57a52a004938b55e55119b2"
+content-hash = "f59639ab082edd913eef142d14cb658cbabd50e6cccdb2617f5360899c3ab58b"
 
 [metadata.files]
 astor = [
@@ -859,26 +859,26 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mypy = [
-    {file = "mypy-0.920-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:41f3575b20714171c832d8f6c7aaaa0d499c9a2d1b8adaaf837b4c9065c38540"},
-    {file = "mypy-0.920-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:431be889ffc8d9681813a45575c42e341c19467cbfa6dd09bf41467631feb530"},
-    {file = "mypy-0.920-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f8b2059f73878e92eff7ed11a03515d6572f4338a882dd7547b5f7dd242118e6"},
-    {file = "mypy-0.920-cp310-cp310-win_amd64.whl", hash = "sha256:9cd316e9705555ca6a50670ba5fb0084d756d1d8cb1697c83820b1456b0bc5f3"},
-    {file = "mypy-0.920-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e091fe58b4475b3504dc7c3022ff7f4af2f9e9ddf7182047111759ed0973bbde"},
-    {file = "mypy-0.920-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98b4f91a75fed2e4c6339e9047aba95968d3a7c4b91e92ab9dc62c0c583564f4"},
-    {file = "mypy-0.920-cp36-cp36m-win_amd64.whl", hash = "sha256:562a0e335222d5bbf5162b554c3afe3745b495d67c7fe6f8b0d1b5bace0c1eeb"},
-    {file = "mypy-0.920-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:618e677aabd21f30670bffb39a885a967337f5b112c6fb7c79375e6dced605d6"},
-    {file = "mypy-0.920-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40cb062f1b7ff4cd6e897a89d8ddc48c6ad7f326b5277c93a8c559564cc1551c"},
-    {file = "mypy-0.920-cp37-cp37m-win_amd64.whl", hash = "sha256:69b5a835b12fdbfeed84ef31152d41343d32ccb2b345256d8682324409164330"},
-    {file = "mypy-0.920-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:993c2e52ea9570e6e872296c046c946377b9f5e89eeb7afea2a1524cf6e50b27"},
-    {file = "mypy-0.920-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:df0fec878ccfcb2d1d2306ba31aa757848f681e7bbed443318d9bbd4b0d0fe9a"},
-    {file = "mypy-0.920-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:331a81d2c9bf1be25317260a073b41f4584cd11701a7c14facef0aa5a005e843"},
-    {file = "mypy-0.920-cp38-cp38-win_amd64.whl", hash = "sha256:ffb1e57ec49a30e3c0ebcfdc910ae4aceb7afb649310b7355509df6b15bd75f6"},
-    {file = "mypy-0.920-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:31895b0b3060baf15bf76e789d94722c026f673b34b774bba9e8772295edccff"},
-    {file = "mypy-0.920-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:140174e872d20d4768124a089b9f9fc83abd6a349b7f8cc6276bc344eb598922"},
-    {file = "mypy-0.920-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:13b3c110309b53f5a62aa1b360f598124be33a42563b790a2a9efaacac99f1fc"},
-    {file = "mypy-0.920-cp39-cp39-win_amd64.whl", hash = "sha256:82e6c15675264e923b60a11d6eb8f90665504352e68edfbb4a79aac7a04caddd"},
-    {file = "mypy-0.920-py3-none-any.whl", hash = "sha256:71c77bd885d2ce44900731d4652d0d1c174dc66a0f11200e0c680bdedf1a6b37"},
-    {file = "mypy-0.920.tar.gz", hash = "sha256:a55438627f5f546192f13255a994d6d1cf2659df48adcf966132b4379fd9c86b"},
+    {file = "mypy-0.931-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a"},
+    {file = "mypy-0.931-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00"},
+    {file = "mypy-0.931-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:300717a07ad09525401a508ef5d105e6b56646f7942eb92715a1c8d610149714"},
+    {file = "mypy-0.931-cp310-cp310-win_amd64.whl", hash = "sha256:7b3f6f557ba4afc7f2ce6d3215d5db279bcf120b3cfd0add20a5d4f4abdae5bc"},
+    {file = "mypy-0.931-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1bf752559797c897cdd2c65f7b60c2b6969ffe458417b8d947b8340cc9cec08d"},
+    {file = "mypy-0.931-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4365c60266b95a3f216a3047f1d8e3f895da6c7402e9e1ddfab96393122cc58d"},
+    {file = "mypy-0.931-cp36-cp36m-win_amd64.whl", hash = "sha256:1b65714dc296a7991000b6ee59a35b3f550e0073411ac9d3202f6516621ba66c"},
+    {file = "mypy-0.931-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e839191b8da5b4e5d805f940537efcaa13ea5dd98418f06dc585d2891d228cf0"},
+    {file = "mypy-0.931-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:50c7346a46dc76a4ed88f3277d4959de8a2bd0a0fa47fa87a4cde36fe247ac05"},
+    {file = "mypy-0.931-cp37-cp37m-win_amd64.whl", hash = "sha256:d8f1ff62f7a879c9fe5917b3f9eb93a79b78aad47b533911b853a757223f72e7"},
+    {file = "mypy-0.931-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9fe20d0872b26c4bba1c1be02c5340de1019530302cf2dcc85c7f9fc3252ae0"},
+    {file = "mypy-0.931-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1b06268df7eb53a8feea99cbfff77a6e2b205e70bf31743e786678ef87ee8069"},
+    {file = "mypy-0.931-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8c11003aaeaf7cc2d0f1bc101c1cc9454ec4cc9cb825aef3cafff8a5fdf4c799"},
+    {file = "mypy-0.931-cp38-cp38-win_amd64.whl", hash = "sha256:d9d2b84b2007cea426e327d2483238f040c49405a6bf4074f605f0156c91a47a"},
+    {file = "mypy-0.931-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ff3bf387c14c805ab1388185dd22d6b210824e164d4bb324b195ff34e322d166"},
+    {file = "mypy-0.931-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5b56154f8c09427bae082b32275a21f500b24d93c88d69a5e82f3978018a0266"},
+    {file = "mypy-0.931-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8ca7f8c4b1584d63c9a0f827c37ba7a47226c19a23a753d52e5b5eddb201afcd"},
+    {file = "mypy-0.931-cp39-cp39-win_amd64.whl", hash = "sha256:74f7eccbfd436abe9c352ad9fb65872cc0f1f0a868e9d9c44db0893440f0c697"},
+    {file = "mypy-0.931-py3-none-any.whl", hash = "sha256:1171f2e0859cfff2d366da2c7092b06130f232c636a3f7301e3feb8b41f6377d"},
+    {file = "mypy-0.931.tar.gz", hash = "sha256:0038b21890867793581e4cb0d810829f5fd4441aa75796b53033af3aa30430ce"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -949,8 +949,8 @@ requests = [
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 responses = [
-    {file = "responses-0.16.0-py2.py3-none-any.whl", hash = "sha256:f358ef75e8bf431b0aa203cc62625c3a1c80a600dbe9de91b944bf4e9c600b92"},
-    {file = "responses-0.16.0.tar.gz", hash = "sha256:a2e3aca2a8277e61257cd3b1c154b1dd0d782b1ae3d38b7fa37cbe3feb531791"},
+    {file = "responses-0.17.0-py2.py3-none-any.whl", hash = "sha256:e4fc472fb7374fb8f84fcefa51c515ca4351f198852b4eb7fc88223780b472ea"},
+    {file = "responses-0.17.0.tar.gz", hash = "sha256:ec675e080d06bf8d1fb5e5a68a1e5cd0df46b09c78230315f650af5e4036bec7"},
 ]
 rich = [
     {file = "rich-11.0.0-py3-none-any.whl", hash = "sha256:d7a8086aa1fa7e817e3bba544eee4fd82047ef59036313147759c11475f0dafd"},
@@ -1002,12 +1002,12 @@ typed-ast = [
     {file = "typed_ast-1.5.1.tar.gz", hash = "sha256:484137cab8ecf47e137260daa20bafbba5f4e3ec7fda1c1e69ab299b75fa81c5"},
 ]
 types-requests = [
-    {file = "types-requests-2.27.5.tar.gz", hash = "sha256:a67dc1a8512312b8cb89f3ba95f9a0e69ef3436ae77c9bd4f328cd88f17adda2"},
-    {file = "types_requests-2.27.5-py3-none-any.whl", hash = "sha256:9c9390b18b222956155af6678570f452edafa3bb94bd5a4efe67da1105aa128c"},
+    {file = "types-requests-2.27.6.tar.gz", hash = "sha256:5e0dc681e9bfadb5c1d17f63d29f6d13d29ef2897d30cb9c79285b34a1655fd7"},
+    {file = "types_requests-2.27.6-py3-none-any.whl", hash = "sha256:8f8a3cf66c525247750b0a0e6ffef4a210d7c8637065a1e7a3cb5769b1eb82a4"},
 ]
 types-urllib3 = [
-    {file = "types-urllib3-1.26.4.tar.gz", hash = "sha256:35c17be09e1bcef3b1e2101c5172b97cdb78330915973c741f4c1979d8405ef9"},
-    {file = "types_urllib3-1.26.4-py3-none-any.whl", hash = "sha256:61a0099899b1472bfbae8ee6ad196950aac46705b99216188aa962ad1e514ed5"},
+    {file = "types-urllib3-1.26.6.tar.gz", hash = "sha256:51b4aff54099896bea28cbdd49d6e7d389dd5ac775d7a4b72c642c56b215d26f"},
+    {file = "types_urllib3-1.26.6-py3-none-any.whl", hash = "sha256:89372ddb3f893b24f3a3cca0113bbc722c73818b9c42dda49f1092501a1ae594"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -517,6 +517,17 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pyupgrade"
+version = "2.31.0"
+description = "A tool to automatically upgrade syntax for newer versions."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+tokenize-rt = ">=3.2.0"
+
+[[package]]
 name = "requests"
 version = "2.27.1"
 description = "Python HTTP for Humans."
@@ -598,6 +609,14 @@ docs = ["sphinx", "zope.component", "sybil", "twisted", "mock", "django (<2)", "
 test = ["pytest (>=3.6)", "pytest-cov", "pytest-django", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
 
 [[package]]
+name = "tokenize-rt"
+version = "4.2.1"
+description = "A wrapper around the stdlib `tokenize` which roundtrips."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -676,7 +695,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2,<4.0"
-content-hash = "ce553e4785b3506614d5aa787bef2ca2d0dbb1f4efdcdfcda85877d1b577fa4b"
+content-hash = "9088014c936470e2143d588c1ca1ac503efc5631e57a52a004938b55e55119b2"
 
 [metadata.files]
 astor = [
@@ -921,6 +940,10 @@ pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
+pyupgrade = [
+    {file = "pyupgrade-2.31.0-py2.py3-none-any.whl", hash = "sha256:0a62c5055f854d7f36e155b7ee8920561bf0399c53edd975cf02436eef8937fc"},
+    {file = "pyupgrade-2.31.0.tar.gz", hash = "sha256:80e2308cae2b11c3fdd091137495d99abf7e0cd98b501aa5758974991497c24c"},
+]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
@@ -944,6 +967,10 @@ snowballstemmer = [
 testfixtures = [
     {file = "testfixtures-6.18.3-py2.py3-none-any.whl", hash = "sha256:6ddb7f56a123e1a9339f130a200359092bd0a6455e31838d6c477e8729bb7763"},
     {file = "testfixtures-6.18.3.tar.gz", hash = "sha256:2600100ae96ffd082334b378e355550fef8b4a529a6fa4c34f47130905c7426d"},
+]
+tokenize-rt = [
+    {file = "tokenize_rt-4.2.1-py2.py3-none-any.whl", hash = "sha256:08a27fa032a81cf45e8858d0ac706004fcd523e8463415ddf1442be38e204ea8"},
+    {file = "tokenize_rt-4.2.1.tar.gz", hash = "sha256:0d4f69026fed520f8a1e0103aa36c406ef4661417f20ca643f913e33531b3b94"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -73,6 +73,17 @@ python2 = ["typed-ast (>=1.4.3)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "blacken-docs"
+version = "1.12.0"
+description = "Run `black` on python code blocks in documentation files"
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+black = ">=19.3b0"
+
+[[package]]
 name = "certifi"
 version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -665,7 +676,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2,<4.0"
-content-hash = "29a7ce960804cc6bdc7e6eb196badf03eabec1b7b43c84f236db0b4889b93911"
+content-hash = "ce553e4785b3506614d5aa787bef2ca2d0dbb1f4efdcdfcda85877d1b577fa4b"
 
 [metadata.files]
 astor = [
@@ -690,6 +701,10 @@ backoff-stubs = [
 black = [
     {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
     {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
+]
+blacken-docs = [
+    {file = "blacken_docs-1.12.0-py2.py3-none-any.whl", hash = "sha256:a81e0abc9771521f445ee582f469c8ec2f5880c19c369d766bb151f79f642d7b"},
+    {file = "blacken_docs-1.12.0.tar.gz", hash = "sha256:3e8138b22c33406cef5946058e535a8aca45cd64b8e7d392b3bd1329fc1f4af8"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -82,7 +82,7 @@ python-versions = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.9"
+version = "2.0.10"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -265,7 +265,7 @@ flake8-plugin-utils = ">=1.3.2,<2.0.0"
 
 [[package]]
 name = "flake8-simplify"
-version = "0.14.2"
+version = "0.14.5"
 description = "flake8 plugin which checks for code that can be simplified"
 category = "dev"
 optional = false
@@ -497,7 +497,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pygments"
-version = "2.11.1"
+version = "2.11.2"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
@@ -553,7 +553,7 @@ testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtuale
 
 [[package]]
 name = "requests"
-version = "2.27.0"
+version = "2.27.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
@@ -658,8 +658,19 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "types-requests"
-version = "2.26.3"
+version = "2.27.5"
 description = "Typing stubs for requests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+types-urllib3 = "<1.27"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.3"
+description = "Typing stubs for urllib3"
 category = "dev"
 optional = false
 python-versions = "*"
@@ -674,7 +685,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "urllib3"
-version = "1.26.7"
+version = "1.26.8"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -743,8 +754,8 @@ certifi = [
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.9.tar.gz", hash = "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"},
-    {file = "charset_normalizer-2.0.9-py3-none-any.whl", hash = "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"},
+    {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
+    {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
 ]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
@@ -850,8 +861,8 @@ flake8-pytest-style = [
     {file = "flake8_pytest_style-1.6.0-py3-none-any.whl", hash = "sha256:5fedb371a950e9fe0e0e6bfc854be7d99151271208f34cd2cc517681ece27780"},
 ]
 flake8-simplify = [
-    {file = "flake8_simplify-0.14.2-py3-none-any.whl", hash = "sha256:6584f3d49350659caaf2a42129f820dc64e60d4bdcb316f621b4e1cfae27e33a"},
-    {file = "flake8_simplify-0.14.2.tar.gz", hash = "sha256:4a8f103607195c3d0743a2fd8beeebe24926e19fb3e24521042cfc35771a8d4d"},
+    {file = "flake8_simplify-0.14.5-py3-none-any.whl", hash = "sha256:9b4b93d75b3c2046883d490df0e8e957b725fcdccf455c0ffe51436d1a098f6b"},
+    {file = "flake8_simplify-0.14.5.tar.gz", hash = "sha256:0bf8b1d60cf35d3e7cf8871194445589778f49ce81a35060f2fe3e0501f5792e"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -946,8 +957,8 @@ pyflakes = [
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pygments = [
-    {file = "Pygments-2.11.1-py3-none-any.whl", hash = "sha256:9135c1af61eec0f650cd1ea1ed8ce298e54d56bcd8cc2ef46edd7702c171337c"},
-    {file = "Pygments-2.11.1.tar.gz", hash = "sha256:59b895e326f0fb0d733fd28c6839bd18ad0687ba20efc26d4277fd1d30b971f4"},
+    {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
+    {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
@@ -962,8 +973,8 @@ pytest-cov = [
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
 requests = [
-    {file = "requests-2.27.0-py2.py3-none-any.whl", hash = "sha256:f71a09d7feba4a6b64ffd8e9d9bc60f9bf7d7e19fd0e04362acb1cfc2e3d98df"},
-    {file = "requests-2.27.0.tar.gz", hash = "sha256:8e5643905bf20a308e25e4c1dd379117c09000bf8a82ebccc462cfb1b34a16b5"},
+    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
+    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 responses = [
     {file = "responses-0.16.0-py2.py3-none-any.whl", hash = "sha256:f358ef75e8bf431b0aa203cc62625c3a1c80a600dbe9de91b944bf4e9c600b92"},
@@ -1015,16 +1026,20 @@ typed-ast = [
     {file = "typed_ast-1.5.1.tar.gz", hash = "sha256:484137cab8ecf47e137260daa20bafbba5f4e3ec7fda1c1e69ab299b75fa81c5"},
 ]
 types-requests = [
-    {file = "types-requests-2.26.3.tar.gz", hash = "sha256:d63fa617846dcefff5aa2d59e47ab4ffd806e4bb0567115f7adbb5e438302fe4"},
-    {file = "types_requests-2.26.3-py3-none-any.whl", hash = "sha256:ad18284931c5ddbf050ccdd138f200d18fd56f88aa3567019d8da9b2d4fe0344"},
+    {file = "types-requests-2.27.5.tar.gz", hash = "sha256:a67dc1a8512312b8cb89f3ba95f9a0e69ef3436ae77c9bd4f328cd88f17adda2"},
+    {file = "types_requests-2.27.5-py3-none-any.whl", hash = "sha256:9c9390b18b222956155af6678570f452edafa3bb94bd5a4efe67da1105aa128c"},
+]
+types-urllib3 = [
+    {file = "types-urllib3-1.26.3.tar.gz", hash = "sha256:e0c57152d7efc408a877adfc9073316dcd3e3ffb39962e90544f7597696c0d7c"},
+    {file = "types_urllib3-1.26.3-py3-none-any.whl", hash = "sha256:580c784925d5902d5fb3b67c0c1019b3d20b8f2d54050f0bb07862d52b93ad03"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
     {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
-    {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
+    {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
+    {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -154,20 +154,6 @@ python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "flake8"
-version = "3.9.2"
-description = "the modular source code checker: pep8 pyflakes and co"
-category = "dev"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-
-[package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.7.0,<2.8.0"
-pyflakes = ">=2.3.0,<2.4.0"
-
-[[package]]
-name = "flake8"
 version = "4.0.1"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
@@ -293,28 +279,12 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
-
-[[package]]
-name = "importlib-metadata"
-version = "4.8.3"
-description = "Read metadata from Python packages"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
 typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -451,14 +421,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycodestyle"
-version = "2.7.0"
-description = "Python style guide checker"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
-name = "pycodestyle"
 version = "2.8.0"
 description = "Python style guide checker"
 category = "dev"
@@ -478,14 +440,6 @@ snowballstemmer = "*"
 
 [package.extras]
 toml = ["toml"]
-
-[[package]]
-name = "pyflakes"
-version = "2.3.1"
-description = "passive checker of Python programs"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyflakes"
@@ -669,7 +623,7 @@ types-urllib3 = "<1.27"
 
 [[package]]
 name = "types-urllib3"
-version = "1.26.3"
+version = "1.26.4"
 description = "Typing stubs for urllib3"
 category = "dev"
 optional = false
@@ -708,22 +662,10 @@ python-versions = ">=3.6"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
-[[package]]
-name = "zipp"
-version = "3.7.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2,<4.0"
-content-hash = "5ff78889ce62ecefd3414ba81e7ccb1bb61801b1f0b4b5365c90b6b60050edad"
+content-hash = "29a7ce960804cc6bdc7e6eb196badf03eabec1b7b43c84f236db0b4889b93911"
 
 [metadata.files]
 astor = [
@@ -827,8 +769,6 @@ dataclasses = [
     {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 flake8 = [
-    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
-    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
@@ -871,8 +811,6 @@ idna = [
 importlib-metadata = [
     {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
     {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
-    {file = "importlib_metadata-4.8.3-py3-none-any.whl", hash = "sha256:65a9576a5b2d58ca44d133c42a241905cc45e34d2c06fd5ba2bafa221e5d7b5e"},
-    {file = "importlib_metadata-4.8.3.tar.gz", hash = "sha256:766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -941,8 +879,6 @@ py = [
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
-    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
     {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
 ]
@@ -951,8 +887,6 @@ pydocstyle = [
     {file = "pydocstyle-6.1.1.tar.gz", hash = "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
-    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
     {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
@@ -1030,8 +964,8 @@ types-requests = [
     {file = "types_requests-2.27.5-py3-none-any.whl", hash = "sha256:9c9390b18b222956155af6678570f452edafa3bb94bd5a4efe67da1105aa128c"},
 ]
 types-urllib3 = [
-    {file = "types-urllib3-1.26.3.tar.gz", hash = "sha256:e0c57152d7efc408a877adfc9073316dcd3e3ffb39962e90544f7597696c0d7c"},
-    {file = "types_urllib3-1.26.3-py3-none-any.whl", hash = "sha256:580c784925d5902d5fb3b67c0c1019b3d20b8f2d54050f0bb07862d52b93ad03"},
+    {file = "types-urllib3-1.26.4.tar.gz", hash = "sha256:35c17be09e1bcef3b1e2101c5172b97cdb78330915973c741f4c1979d8405ef9"},
+    {file = "types_urllib3-1.26.4-py3-none-any.whl", hash = "sha256:61a0099899b1472bfbae8ee6ad196950aac46705b99216188aa962ad1e514ed5"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
@@ -1044,6 +978,4 @@ urllib3 = [
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
     {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
-    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
-    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -587,7 +587,7 @@ tests = ["coverage (>=3.7.1,<6.0.0)", "pytest-cov", "pytest-localserver", "flake
 
 [[package]]
 name = "rich"
-version = "10.16.2"
+version = "11.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 category = "main"
 optional = false
@@ -723,7 +723,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2,<4.0"
-content-hash = "9829b4fb43510677f8960377ef061dab038c359715f4f6919a92407b87736ee8"
+content-hash = "5ff78889ce62ecefd3414ba81e7ccb1bb61801b1f0b4b5365c90b6b60050edad"
 
 [metadata.files]
 astor = [
@@ -981,8 +981,8 @@ responses = [
     {file = "responses-0.16.0.tar.gz", hash = "sha256:a2e3aca2a8277e61257cd3b1c154b1dd0d782b1ae3d38b7fa37cbe3feb531791"},
 ]
 rich = [
-    {file = "rich-10.16.2-py3-none-any.whl", hash = "sha256:c59d73bd804c90f747c8d7b1d023b88f2a9ac2454224a4aeaf959b21eeb42d03"},
-    {file = "rich-10.16.2.tar.gz", hash = "sha256:720974689960e06c2efdb54327f8bf0cdbdf4eae4ad73b6c94213cad405c371b"},
+    {file = "rich-11.0.0-py3-none-any.whl", hash = "sha256:d7a8086aa1fa7e817e3bba544eee4fd82047ef59036313147759c11475f0dafd"},
+    {file = "rich-11.0.0.tar.gz", hash = "sha256:c32a8340b21c75931f157466fefe81ae10b92c36a5ea34524dff3767238774a4"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ parameterized = "^0.8.1"
 mypy = "^0.920"
 types-requests = ">=2.26.0"
 backoff-stubs = "*"
+pyupgrade = "^2.31.0"
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,7 @@ python = ">=3.6.2,<4.0"
 requests = ">=2.26.0"
 backoff = "^1.11.1"
 rich = ">=10.16.2"
-importlib-metadata = [
-    { version = "^4.6.1", markers = "python_version < '3.8'" },
-    { version = "*", markers = "python_version >= '3.8'" }
-]
+importlib-metadata = { version = "*", markers = "python_version < '3.8'" }
 
 [tool.poetry.dev-dependencies]
 # Lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ flake8 = "*"
 flake8-docstrings = "^1.6.0"
 flake8-pytest-style = "^1.6.0"
 flake8-simplify = "^0.14.2"
-flake8-comprehensions = "^3.7.0"
+flake8-comprehensions = "^3.7.0" # Last version to support Python 3.6
 flake8-isort = "^4.1.1"
 isort = "^5.10.1"
 pep8-naming = "^0.12.1"
@@ -68,13 +68,16 @@ darglint = "^1.8.1"
 # Tests
 pytest = "^6.2.5"
 pytest-cov = "^3.0.0"
-responses = "^0.16.0"
+responses = "^0.17.0"
 parameterized = "^0.8.1"
 # Types
-mypy = "^0.920"
+mypy = "^0.931"
 types-requests = ">=2.26.0"
 backoff-stubs = "*"
 pyupgrade = "^2.31.0"
+
+[tool.black]
+target-version = ['py36']
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ censys = "censys.cli:main"
 python = ">=3.6.2,<4.0"
 requests = ">=2.26.0"
 backoff = "^1.11.1"
-rich = "^10.16.2"
+rich = ">=10.16.2"
 importlib-metadata = [
     { version = "^4.6.1", markers = "python_version < '3.8'" },
     { version = "*", markers = "python_version >= '3.8'" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ isort = "^5.10.1"
 pep8-naming = "^0.12.1"
 flake8-black = "^0.2.3"
 black = "^21.12b0"
+blacken-docs = "^1.12.0"
 darglint = "^1.8.1"
 # Tests
 pytest = "^6.2.5"
@@ -71,7 +72,7 @@ responses = "^0.16.0"
 parameterized = "^0.8.1"
 # Types
 mypy = "^0.920"
-types-requests = "^2.26.3"
+types-requests = ">=2.26.0"
 backoff-stubs = "*"
 
 [tool.isort]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-testpaths = 
+testpaths =
     tests
 # Ignore warnings for deprecation
 addopts = --cov -rs

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
-testpaths =
-    tests
+testpaths = tests
 # Ignore warnings for deprecation
 addopts = --cov -rs
 filterwarnings=

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,6 +7,7 @@ import pytest
 from tests.utils import CensysTestCase
 
 from censys.cli import main as cli_main
+from censys.cli.commands import __all__ as cli_commands
 from censys.common import __version__
 
 
@@ -27,7 +28,7 @@ class CensysCliTest(CensysTestCase):
 
         stdout = temp_stdout.getvalue().strip()
         assert stdout.startswith("usage: censys")
-        assert "{account,asm,config,hnri,search,view}" in stdout
+        assert "{" + ",".join(sorted(cli_commands)) + "}" in stdout
         assert "-v, --version" in stdout
 
     @patch("argparse._sys.argv", ["censys", "-v"])

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -167,6 +167,6 @@ class CensysConfigTest(unittest.TestCase):
     @patch("censys.common.config.os.path.isfile", os.path.isfile)
     def test_config_default(self):
         config = get_config()
+        os.path.isfile.assert_called_with(test_config_path)
         for key, value in default_config.items():
             assert value == config.get(DEFAULT, key)
-        os.path.isfile.ASSERT_CALLED_WITH(test_config_path)

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
@@ -163,7 +162,7 @@ class CensysConfigCliTest(CensysTestCase):
 
 
 @patch("censys.common.config.CONFIG_PATH", test_config_path)
-class CensysConfigTest(unittest.TestCase):
+class CensysConfigTest(CensysTestCase):
     @patch("censys.common.config.os.path.isfile", os.path.isfile)
     def test_config_default(self):
         config = get_config()

--- a/tests/search/v2/test_api.py
+++ b/tests/search/v2/test_api.py
@@ -1,5 +1,4 @@
 import unittest
-from typing import Type
 from unittest.mock import mock_open, patch
 
 import pytest
@@ -20,7 +19,7 @@ SearchExceptionParams = [
 
 
 class CensysSearchAPITests(CensysTestCase):
-    api: Type[CensysSearchAPIv2]
+    api: CensysSearchAPIv2
 
     def setUp(self):
         super().setUp()

--- a/tests/search/v2/test_comments.py
+++ b/tests/search/v2/test_comments.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import responses
 from parameterized import parameterized_class
 
@@ -50,9 +48,9 @@ ADD_COMMENTS_RESPONSE = {
 )
 class CensysCommentsTests(CensysTestCase):
     index: str
-    index_cls: Type[CensysSearchAPIv2]
+    index_cls: CensysSearchAPIv2
     document_id: str
-    api: Type[CensysSearchAPIv2]
+    api: CensysSearchAPIv2
 
     def setUp(self):
         super().setUp()

--- a/tests/search/v2/test_tags.py
+++ b/tests/search/v2/test_tags.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import pytest
 import responses
 from parameterized import parameterized_class
@@ -71,9 +69,9 @@ LIST_CERTS_RESPONSE = {
 )
 class CensysTagsTests(CensysTestCase):
     index: str
-    index_cls: Type[CensysSearchAPIv2]
+    index_cls: CensysSearchAPIv2
     document_id: str
-    api: Type[CensysSearchAPIv2]
+    api: CensysSearchAPIv2
 
     def setUp(self):
         super().setUp()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,4 @@
 import unittest
-from typing import Type
 
 import responses
 
@@ -24,7 +23,7 @@ class CensysTestCase(unittest.TestCase):
         "--api-key",
         api_key,
     ]
-    api: Type[CensysAPIBase]
+    api: CensysAPIBase
 
     def setUp(self):
         self.responses = responses.RequestsMock()
@@ -33,6 +32,6 @@ class CensysTestCase(unittest.TestCase):
         self.addCleanup(self.responses.stop)
         self.addCleanup(self.responses.reset)
 
-    def setUpApi(self, api: Type[CensysAPIBase]):  # noqa: N802
+    def setUpApi(self, api: CensysAPIBase):  # noqa: N802
         self.api = api
         self.base_url = self.api._api_url


### PR DESCRIPTION
## Changes

- Added support for `/api/v2/hosts/{ip}/diff` ([Docs](https://search.censys.io/api#/hosts/viewHostDiff))
- Improved multithreaded API methods
- Improved CLI error handling
- Improved config options
- Fixed `importlib-metadata` version conflicts
- Added `blacken-docs` and `pyupgrade`
- Updated docs
- Updated tests

## How to test

1. Run `poetry run pytest`
2. Try running examples in `examples/search/view_host_diff.py`