### PR TITLE
Edit output format options for Search/View CLI

### DIFF
--- a/censys/cli/commands/view.py
+++ b/censys/cli/commands/view.py
@@ -68,7 +68,7 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
         type=str,
         help="a document id (IP address) to view",
     )
-    view_parser.add_argument(  # ?? there is only one choice, so can only do json
+    view_parser.add_argument(
         "--index-type",
         type=str,
         default="hosts",
@@ -86,7 +86,7 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
         "-o",
         "--output",
         type=str,
-        help="json output file path",  # ?? is this always json?
+        help="json output file path",
     )
     view_parser.add_argument(
         "-O",

--- a/censys/cli/commands/view.py
+++ b/censys/cli/commands/view.py
@@ -36,7 +36,6 @@ def cli_view(args: argparse.Namespace):
     write_args = {
         "file_format": "json" if args.output else "screen",
         "file_path": args.output,
-        "base_name": f"censys-view-{args.document_id}",
     }
 
     if args.at_time:
@@ -69,7 +68,7 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
         type=str,
         help="a document id (IP address) to view",
     )
-    view_parser.add_argument(
+    view_parser.add_argument(  # ?? there is only one choice, so can only do json
         "--index-type",
         type=str,
         default="hosts",
@@ -87,7 +86,7 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
         "-o",
         "--output",
         type=str,
-        help="json output file path",
+        help="json output file path",  # ?? is this always json?
     )
     view_parser.add_argument(
         "-O",

--- a/censys/cli/utils.py
+++ b/censys/cli/utils.py
@@ -100,7 +100,8 @@ def write_file(
     """
     if file_format and isinstance(file_format, str):
         file_format = file_format.lower()
-    else:
+
+    if not file_path:
         file_path = "temp-out.json"
 
     if file_format == "json":

--- a/censys/cli/utils.py
+++ b/censys/cli/utils.py
@@ -96,7 +96,6 @@ def write_file(
         results_list (Results): A list of results from the API query.
         file_format (str): Optional; The format of the output.
         file_path (str): Optional; A path to write results to.
-        base_name (str): Optional; The base name of the output file.
         csv_fields (List[str]): Optional; A list of fields to write to CSV.
     """
     if file_format and isinstance(file_format, str):

--- a/censys/cli/utils.py
+++ b/censys/cli/utils.py
@@ -87,7 +87,7 @@ def _write_screen(search_results: Results):  # pragma: no cover
 def write_file(
     results_list: Results,
     file_format: Optional[str] = None,
-    file_path: Optional[str] = None,
+    file_path: str = "censys-certs.json",
     csv_fields: List[str] = [],
 ):
     """Maps formats and writes results.

--- a/censys/cli/utils.py
+++ b/censys/cli/utils.py
@@ -87,7 +87,7 @@ def _write_screen(search_results: Results):  # pragma: no cover
 def write_file(
     results_list: Results,
     file_format: Optional[str] = None,
-    file_path: str = "censys-certs.json",
+    file_path: Optional[str] = None,
     csv_fields: List[str] = [],
 ):
     """Maps formats and writes results.

--- a/censys/cli/utils.py
+++ b/censys/cli/utils.py
@@ -86,9 +86,8 @@ def _write_screen(search_results: Results):  # pragma: no cover
 
 def write_file(
     results_list: Results,
-    file_format: str = "screen",
+    file_format: Optional[str] = None,
     file_path: Optional[str] = None,
-    base_name: str = "censys-query-output",
     csv_fields: List[str] = [],
 ):
     """Maps formats and writes results.
@@ -102,12 +101,6 @@ def write_file(
     """
     if file_format and isinstance(file_format, str):
         file_format = file_format.lower()
-
-    if not file_path:
-        # This method just creates some dynamic file names
-        file_path = ".".join([base_name, file_format])
-    elif file_path.endswith(".json"):
-        file_format = "json"
 
     if file_format == "json":
         _write_json(file_path, results_list)

--- a/censys/cli/utils.py
+++ b/censys/cli/utils.py
@@ -100,6 +100,8 @@ def write_file(
     """
     if file_format and isinstance(file_format, str):
         file_format = file_format.lower()
+    else:
+        file_path = "temp-out.json"
 
     if file_format == "json":
         _write_json(file_path, results_list)

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -44,11 +44,11 @@ Below we show an example of Viewing a host from the CLI.
 
     censys view 8.8.8.8
 
-You can save results to a file using the ``-f`` and ``-o`` arguments.
+You can save results to a file using the ``-o`` argument.
 
 .. prompt:: bash
 
-    censys view 8.8.8.8 -f json -o google.json
+    censys view 8.8.8.8 -o google.json
 
 We can then parse this json with something like ``jq``.
 

--- a/tests/cli/test_search.py
+++ b/tests/cli/test_search.py
@@ -55,8 +55,8 @@ class CensysCliSearchTest(CensysTestCase):
             "certs",
             "--fields",
             "parsed.issuer.country",
-            "--format",
-            "json",
+            "--output",
+            "censys-certs.json",
         ]
         + CensysTestCase.cli_args,
     )
@@ -77,7 +77,7 @@ class CensysCliSearchTest(CensysTestCase):
 
         json_path = cli_response.replace(WROTE_PREFIX, "").strip()
         assert json_path.endswith(".json")
-        assert "censys-query-output." in json_path
+        assert "censys-certs." in json_path
 
         with open(json_path) as json_file:
             json_response = json.load(json_file)
@@ -98,8 +98,8 @@ class CensysCliSearchTest(CensysTestCase):
             "certs",
             "--fields",
             "protocols",
-            "--format",
-            "csv",
+            "--output",
+            "censys-certs.csv",
         ]
         + CensysTestCase.cli_args,
     )
@@ -120,7 +120,7 @@ class CensysCliSearchTest(CensysTestCase):
 
         csv_path = cli_response.replace(WROTE_PREFIX, "").strip()
         assert csv_path.endswith(".csv")
-        assert "censys-query-output." in csv_path
+        assert "censys-certs." in csv_path
 
         with open(csv_path) as csv_file:
             csv_reader = csv.reader(csv_file)
@@ -141,8 +141,6 @@ class CensysCliSearchTest(CensysTestCase):
             "certs",
             "--fields",
             "parsed.issuer.country",
-            "--format",
-            "json",
             "--output",
             "censys-certs.json",
         ]
@@ -181,8 +179,6 @@ class CensysCliSearchTest(CensysTestCase):
             "certs",
             "--fields",
             "443.https.get.headers.server",
-            "--format",
-            "screen",
         ]
         + CensysTestCase.cli_args,
     )
@@ -220,8 +216,6 @@ class CensysCliSearchTest(CensysTestCase):
             "443.https.tls.cipher_suite.name",
             "443.https.get.title",
             "443.https.get.headers.server",
-            "--format",
-            "screen",
         ]
         + CensysTestCase.cli_args,
     )
@@ -300,8 +294,6 @@ class CensysCliSearchTest(CensysTestCase):
             "parsed.names: censys.io",
             "--index-type",
             "certs",
-            "--format",
-            "screen",
             "--max-records",
             "2",
         ]
@@ -331,8 +323,6 @@ class CensysCliSearchTest(CensysTestCase):
             "service.service_name: HTTP",
             "--index-type",
             "hosts",
-            "--format",
-            "screen",
             "--pages",
             "1",
         ]
@@ -363,8 +353,6 @@ class CensysCliSearchTest(CensysTestCase):
             "service.service_name: HTTP",
             "--index-type",
             "hosts",
-            "--format",
-            "screen",
             "--pages",
             "1",
             "--virtual-hosts",
@@ -397,17 +385,17 @@ class CensysCliSearchTest(CensysTestCase):
             "service.service_name: HTTP",
             "--index-type",
             "hosts",
-            "--format",
-            "csv",
             "--pages",
             "1",
+            "--output",
+            "censys-hosts.csv",
         ]
         + CensysTestCase.cli_args,
     )
     def test_write_csv_v2(self):
         with pytest.raises(
             CensysCLIException,
-            match="CSV output is not supported for the hosts index.",
+            match="JSON is the only valid file format for Search 2.0 responses.",
         ):
             cli_main()
 


### PR DESCRIPTION
- Removed `--format` (`-f`) option from Search CLI
  - Now determines format based on output filename extension
  - V1 supports JSON and print to screen
  - V2 supports JSON, CSV, and print to screen
  - If output file is specified with an invalid extension, output will print to screen in JSON format
  - This takes away the option of specifying format without a filename, which autogenerates filenames for the user
- Changed warning message to be more specific
- Edited search and view tests