### PR TITLE
Update Testing section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ poetry install
 
 ```sh
 # Run tests
-pytest
+poetry run pytest
 # With coverage report
-pytest --cov-report html
+poetry run pytest --cov-report html
 ```
 
 ## License


### PR DESCRIPTION
I find that if I use pytest which is installed with system package manager, pytest cannot find metadata of censys. After checking what is written in CI, I realize the right way to check.