### PR TITLE
feat: Add API support for asset discovery trails

### DIFF
--- a/censys/asm/assets/assets.py
+++ b/censys/asm/assets/assets.py
@@ -29,6 +29,7 @@ class Assets(CensysAsmAPI):
         tag: Optional[List[str]] = None,
         tag_operator: Optional[str] = None,
         source: Optional[List[str]] = None,
+        discovery_trail: Optional[bool] = None,
     ) -> Iterator[dict]:
         """Requests assets data.
 
@@ -38,6 +39,7 @@ class Assets(CensysAsmAPI):
             tag (list): Optional; List of tags to search for.
             tag_operator (str): Optional; Operator to use when searching for tags.
             source (list): Optional; List of sources to search for.
+            discovery_trail (bool): Optional; Bool indicating whether to return discovery trail.
 
         Yields:
             dict: The assets result returned.
@@ -49,6 +51,8 @@ class Assets(CensysAsmAPI):
             args["tagOperator"] = tag_operator
         if source:
             args["source"] = source
+        if discovery_trail:
+            args["discoveryTrail"] = discovery_trail
         yield from self._get_page(
             self.base_path, page_number=page_number, page_size=page_size, args=args
         )

--- a/censys/asm/assets/subdomains.py
+++ b/censys/asm/assets/subdomains.py
@@ -25,6 +25,7 @@ class SubdomainsAssets(Assets):
         tag: Optional[List[str]] = None,
         tag_operator: Optional[str] = None,
         source: Optional[List[str]] = None,
+        discovery_trail: Optional[bool] = None,
     ) -> Iterator[dict]:
         """Requests assets data.
 
@@ -47,6 +48,8 @@ class SubdomainsAssets(Assets):
             args["tagOperator"] = tag_operator
         if source:
             args["source"] = source
+        if discovery_trail:
+            args["discoveryTrail"] = discovery_trail
         yield from self._get_page(
             self.base_path,
             page_number=page_number,

--- a/censys/asm/assets/subdomains.py
+++ b/censys/asm/assets/subdomains.py
@@ -37,6 +37,7 @@ class SubdomainsAssets(Assets):
             tag (list): Optional; List of tags to search for.
             tag_operator (str): Optional; Operator to use when searching for tags.
             source (list): Optional; List of sources to search for.
+            discovery_trail (bool): Optional; Bool indicating whether to return discovery trail.
 
         Yields:
             dict: The assets result returned.

--- a/tests/asm/test_assets.py
+++ b/tests/asm/test_assets.py
@@ -80,7 +80,7 @@ class AssetsUnitTest(unittest.TestCase):
     def test_get_assets_by_tag(self, mock):
         mock.return_value = MockResponse(TEST_SUCCESS_CODE, self.resource_type)
         assets = self.get_asset_accessor().get_assets(
-            tag=[TEST_TAG_NAME], tag_operator="is", source=["Seed"]
+            tag=[TEST_TAG_NAME], tag_operator="is", source=["Seed"], discovery_trail=True
         )
         res = list(assets)
 
@@ -93,6 +93,7 @@ class AssetsUnitTest(unittest.TestCase):
                 "tag": [TEST_TAG_NAME],
                 "tagOperator": "is",
                 "source": ["Seed"],
+                "discoveryTrail": True,
             },
             timeout=TEST_TIMEOUT,
         )

--- a/tests/asm/test_assets.py
+++ b/tests/asm/test_assets.py
@@ -80,7 +80,10 @@ class AssetsUnitTest(unittest.TestCase):
     def test_get_assets_by_tag(self, mock):
         mock.return_value = MockResponse(TEST_SUCCESS_CODE, self.resource_type)
         assets = self.get_asset_accessor().get_assets(
-            tag=[TEST_TAG_NAME], tag_operator="is", source=["Seed"], discovery_trail=True
+            tag=[TEST_TAG_NAME],
+            tag_operator="is",
+            source=["Seed"],
+            discovery_trail=True,
         )
         res = list(assets)
 


### PR DESCRIPTION
The Censys API offers a parameter that allows pulling back discovery trails, but this parameter is not currently exposed via this library. This commit adds support for this parameter.