### PR TITLE
Add post search methods for hosts

### DIFF
--- a/censys/search/v2/certs.py
+++ b/censys/search/v2/certs.py
@@ -1,5 +1,5 @@
 """Interact with the Censys Search Cert API."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from .api import CensysSearchAPIv2
 
@@ -125,7 +125,7 @@ class CensysCerts(CensysSearchAPIv2):
         per_page: int = 50,
         cursor: Optional[str] = None,
         fields: Optional[List[str]] = None,
-        sort: Optional[List[str]] = None,
+        sort: Optional[Union[str, List[str]]] = None,
         **kwargs,
     ) -> dict:
         """Searches the Certs index using the POST method. Returns the raw response.
@@ -141,18 +141,14 @@ class CensysCerts(CensysSearchAPIv2):
         Returns:
             dict: Search results.
         """
-        data = {
-            "q": query,
-            "per_page": per_page,
-        }
-        if cursor:
-            data["cursor"] = cursor
-        if fields:
-            data["fields"] = fields
-        if sort:
-            data["sort"] = sort
-        data.update(kwargs)
-        return self._post(self.search_path, data=data)
+        return super().search_post_raw(
+            query=query,
+            per_page=per_page,
+            cursor=cursor,
+            fields=fields,
+            sort=sort,
+            **kwargs,
+        )
 
     def search_post(
         self,
@@ -160,7 +156,7 @@ class CensysCerts(CensysSearchAPIv2):
         per_page: int = 50,
         cursor: Optional[str] = None,
         fields: Optional[List[str]] = None,
-        sort: Optional[List[str]] = None,
+        sort: Optional[Union[str, List[str]]] = None,
         **kwargs,
     ) -> dict:
         """Searches the Certs index using the POST method.
@@ -179,14 +175,14 @@ class CensysCerts(CensysSearchAPIv2):
         Returns:
             dict: Search results.
         """
-        return self.search_post_raw(
+        return super().search_post(
             query=query,
             per_page=per_page,
             cursor=cursor,
             fields=fields,
             sort=sort,
             **kwargs,
-        )["result"]
+        )
 
     def search_get(
         self,
@@ -194,7 +190,8 @@ class CensysCerts(CensysSearchAPIv2):
         per_page: int = 50,
         cursor: Optional[str] = None,
         fields: Optional[List[str]] = None,
-        sort: Optional[List[str]] = None,
+        sort: Optional[Union[str, List[str]]] = None,
+        **kwargs,
     ) -> dict:
         """Searches the Certs index using the GET method.
 
@@ -204,18 +201,19 @@ class CensysCerts(CensysSearchAPIv2):
             cursor (str, optional): Cursor token from the API response, which fetches the next page of results when added to the endpoint URL.
             fields (List[str], optional): Additional fields to return in the matched certificates outside of the default returned fields.
             sort (List[str], optional): A list of fields to sort on. By default, fields will be sorted in ascending order.
+            **kwargs: Arbitrary keyword arguments.
 
         Returns:
             dict: Search results.
         """
-        args = {
-            "q": query,
-            "per_page": per_page,
-            "cursor": cursor,
-            "fields": fields,
-            "sort": sort,
-        }
-        return self._get(self.search_path, args=args)["result"]
+        return super().search_get(
+            query=query,
+            per_page=per_page,
+            cursor=cursor,
+            fields=fields,
+            sort=sort,
+            **kwargs,
+        )
 
     def raw_search(
         self,
@@ -223,7 +221,7 @@ class CensysCerts(CensysSearchAPIv2):
         per_page: int = 50,
         cursor: Optional[str] = None,
         fields: Optional[List[str]] = None,
-        sort: Optional[List[str]] = None,
+        sort: Optional[Union[str, List[str]]] = None,
         **kwargs,
     ) -> dict:
         """Searches the Certs index.
@@ -242,7 +240,7 @@ class CensysCerts(CensysSearchAPIv2):
         Returns:
             dict: Search results.
         """
-        return self.search_post_raw(
+        return super().raw_search(
             query=query,
             per_page=per_page,
             cursor=cursor,
@@ -258,7 +256,7 @@ class CensysCerts(CensysSearchAPIv2):
         cursor: Optional[str] = None,
         pages: int = 1,
         fields: Optional[List[str]] = None,
-        sort: Optional[List[str]] = None,
+        sort: Optional[Union[str, List[str]]] = None,
         **kwargs,
     ) -> CensysSearchAPIv2.Query:
         """Searches the Certs index.
@@ -278,11 +276,7 @@ class CensysCerts(CensysSearchAPIv2):
         Returns:
             Query: A query object that can be used to iterate over the search results.
         """
-        if fields:
-            kwargs["fields"] = fields
-        if sort:
-            kwargs["sort"] = sort
-        return super().search(query, per_page, cursor, pages, **kwargs)
+        return super().search(query, per_page, cursor, pages, fields, sort, **kwargs)
 
     def aggregate(
         self, query: str, field: str, num_buckets: int = 50, **kwargs

--- a/censys/search/v2/hosts.py
+++ b/censys/search/v2/hosts.py
@@ -1,5 +1,5 @@
 """Interact with the Censys Search Host API."""
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from .api import CensysSearchAPIv2
 from censys.common.types import Datetime
@@ -145,6 +145,7 @@ class CensysHosts(CensysSearchAPIv2):
         cursor: Optional[str] = None,
         pages: int = 1,
         fields: Optional[List[str]] = None,
+        sort: Optional[Union[str, List[str]]] = None,
         virtual_hosts: Optional[str] = None,
         **kwargs: Any,
     ) -> CensysSearchAPIv2.Query:
@@ -159,6 +160,7 @@ class CensysHosts(CensysSearchAPIv2):
             cursor (int): Optional; The cursor of the desired result set.
             pages (int): Optional; The number of pages returned. Defaults to 1.
             fields (List[str]): Optional; The fields to return. Defaults to all fields.
+            sort (str): Optional; The method used to sort results. Valid values are "RELEVANCE", "DESCENDING", and "ASCENDING".
             virtual_hosts (str): Optional; Whether to include virtual hosts in the results. Valid values are "EXCLUDE", "INCLUDE", and "ONLY".
             **kwargs (Any): Optional; Additional arguments to be passed to the query.
 
@@ -167,9 +169,7 @@ class CensysHosts(CensysSearchAPIv2):
         """
         if virtual_hosts:
             kwargs["virtual_hosts"] = virtual_hosts
-        if fields:
-            kwargs["fields"] = fields
-        return super().search(query, per_page, cursor, pages, **kwargs)
+        return super().search(query, per_page, cursor, pages, fields, sort, **kwargs)
 
     def aggregate(
         self,

--- a/tests/cli/test_search.py
+++ b/tests/cli/test_search.py
@@ -12,6 +12,7 @@ import pytest
 import responses
 from parameterized import parameterized
 from requests import PreparedRequest
+from responses import matchers
 
 from tests.search.v2.test_certs import SEARCH_CERTS_JSON
 from tests.search.v2.test_hosts import (
@@ -130,11 +131,20 @@ class CensysCliSearchTest(CensysTestCase):
     def test_write_screen(self):
         # Setup response
         self.responses.add(
-            responses.GET,
-            V2_URL
-            + "/hosts/search?q=services.service_name: HTTP&per_page=100&sort=RELEVANCE&virtual_hosts=EXCLUDE",
+            responses.POST,
+            V2_URL + "/hosts/search",
             status=200,
             json=SEARCH_HOSTS_JSON,
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "q": "services.service_name: HTTP",
+                        "per_page": 100,
+                        "sort": "RELEVANCE",
+                        "virtual_hosts": "EXCLUDE",
+                    }
+                )
+            ],
         )
         # Mock
         self.patch_args(
@@ -162,11 +172,20 @@ class CensysCliSearchTest(CensysTestCase):
     def test_search_virtual_hosts(self):
         # Setup response
         self.responses.add(
-            responses.GET,
-            V2_URL
-            + "/hosts/search?q=services.service_name%3A+HTTP&per_page=100&sort=RELEVANCE&virtual_hosts=ONLY",
+            responses.POST,
+            V2_URL + "/hosts/search",
             status=200,
             json=SEARCH_HOSTS_JSON,
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "q": "services.service_name: HTTP",
+                        "per_page": 100,
+                        "sort": "RELEVANCE",
+                        "virtual_hosts": "ONLY",
+                    }
+                )
+            ],
         )
         # Mock
         self.patch_args(
@@ -196,11 +215,20 @@ class CensysCliSearchTest(CensysTestCase):
     def test_search_sort_order(self):
         # Setup response
         self.responses.add(
-            responses.GET,
-            V2_URL
-            + "/hosts/search?q=services.service_name%3A+HTTP&per_page=100&sort=RANDOM&virtual_hosts=EXCLUDE",
+            responses.POST,
+            V2_URL + "/hosts/search",
             status=200,
             json=SEARCH_HOSTS_JSON,
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "q": "services.service_name: HTTP",
+                        "per_page": 100,
+                        "sort": "DESCENDING",
+                        "virtual_hosts": "EXCLUDE",
+                    }
+                )
+            ],
         )
         # Mock
         self.patch_args(
@@ -213,7 +241,7 @@ class CensysCliSearchTest(CensysTestCase):
                 "--pages",
                 "1",
                 "--sort-order",
-                "RANDOM",
+                "DESCENDING",
             ],
             search_auth=True,
         )
@@ -230,11 +258,20 @@ class CensysCliSearchTest(CensysTestCase):
     def test_write_json(self):
         # Setup response
         self.responses.add(
-            responses.GET,
-            V2_URL
-            + "/hosts/search?q=services.service_name: HTTP&per_page=100&sort=RELEVANCE&virtual_hosts=EXCLUDE",
+            responses.POST,
+            V2_URL + "/hosts/search",
             status=200,
             json=SEARCH_HOSTS_JSON,
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "q": "services.service_name: HTTP",
+                        "per_page": 100,
+                        "sort": "RELEVANCE",
+                        "virtual_hosts": "EXCLUDE",
+                    }
+                )
+            ],
         )
         # Mock
         self.patch_args(
@@ -307,18 +344,37 @@ class CensysCliSearchTest(CensysTestCase):
         # Setup response
         next_cursor = SEARCH_HOSTS_JSON["result"]["links"]["next"]
         self.responses.add(
-            responses.GET,
-            V2_URL
-            + "/hosts/search?q=services.service_name: HTTP&per_page=100&sort=RELEVANCE&virtual_hosts=EXCLUDE",
+            responses.POST,
+            V2_URL + "/hosts/search",
             status=200,
             json=SEARCH_HOSTS_JSON,
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "q": "services.service_name: HTTP",
+                        "per_page": 100,
+                        "sort": "RELEVANCE",
+                        "virtual_hosts": "EXCLUDE",
+                    }
+                )
+            ],
         )
         self.responses.add(
-            responses.GET,
-            V2_URL
-            + f"/hosts/search?q=services.service_name: HTTP&per_page=100&sort=RELEVANCE&virtual_hosts=EXCLUDE&cursor={next_cursor}",
+            responses.POST,
+            V2_URL + "/hosts/search",
             status=status_code,
             json=json_response,
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "q": "services.service_name: HTTP",
+                        "per_page": 100,
+                        "sort": "RELEVANCE",
+                        "virtual_hosts": "EXCLUDE",
+                        "cursor": next_cursor,
+                    }
+                )
+            ],
         )
         # Mock
         self.patch_args(


### PR DESCRIPTION
# Description

Updated `CensysSearchAPIv2` to have both POST methods for search. Switched to use POST by default.

# Changes

- Updated `CensysSearchAPIv2` to have both POST and GET methods for search.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
