### PR TITLE
feat: add support for setting x-request-id header

### DIFF
--- a/censys/common/base.py
+++ b/censys/common/base.py
@@ -98,6 +98,7 @@ class CensysAPIBase:
             self._session.proxies.update(proxies)
         if cookies:
             self._session.cookies.update(cookies)
+        self.request_id = kwargs.get("request_id")
         self._session.headers.update(
             {
                 "accept": "application/json, */8",
@@ -111,6 +112,29 @@ class CensysAPIBase:
                 ),
             }
         )
+
+    @property
+    def request_id(self) -> Optional[str]:
+        """The x-request-id header value for API requests.
+
+        The x-request-id header is not set when the value is None.
+        Value is None by default
+
+        Returns:
+            Type[Optional[str]]: The value of the header.
+        """
+        value = self._session.headers.get("x-request-id")
+        if not isinstance(value, str):
+            return None
+        return value
+
+    @request_id.setter
+    def request_id(self, value: Optional[str]):
+        if value is None:
+            self._session.headers.pop("x-request-id", None)
+            return
+
+        self._session.headers["x-request-id"] = value
 
     @staticmethod
     def _get_exception_class(_: Response) -> Type[CensysAPIException]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "censys"
-version = "2.2.11"
+version = "2.2.12"
 description = "An easy-to-use and lightweight API wrapper for Censys APIs (censys.io)."
 authors = ["Censys, Inc. <support@censys.io>"]
 license = "Apache-2.0"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -96,6 +96,19 @@ class CensysAPIBaseTests(CensysTestCase):
             == requests.utils.default_user_agent() + " test"
         )
 
+    def test_request_id(self):
+        id_value = "my-request-id"
+
+        # Test request id value is present
+        base = CensysAPIBase(TEST_URL, request_id=id_value)
+        assert base.request_id == id_value
+        assert base._session.headers.get("x-request-id") == id_value
+
+        # Test request id value is not present
+        base.request_id = None
+        assert base.request_id is None
+        assert base._session.headers.get("x-request-id") is None
+
     @pytest.mark.filterwarnings("ignore:HTTP proxies will not be used.")
     def test_proxies(self):
         # Mock/actual call


### PR DESCRIPTION
This PR adds mediocre support for setting request ids to support request debugging.

Methods on `censys.search.{CensysHosts|CensysCerts}` don't support configuring the underlying request object on each call. Given that `**kwargs` is used to glob additional search params on most methods, I didn't see a clean and consistent way to support setting one-off request options through the query methods themselves.

Support for setting the x-request-id header is implemented by adding a property to the `CensysAPIBase` class, where updates will mutate the request objects headers, so that the next request will include the assigned request-id value.

This leads to an awkward, though functional, usage pattern:
```python
from censys.search import CensysHosts

h = CensysHosts(request_id="test-id-0")
host = h.view("8.8.8.8")                    # request with  x-request-id: test-id-0

h.request_id = "test-id-1"
host = h.view("8.8.8.8")                    # request with  x-request-id: test-id-1

host = h.view("8.8.8.8")                    # request with  x-request-id: test-id-1

h.request_id = "test-id-2"
host = h.view("8.8.8.8")                    # request with  x-request-id: test-id-2

h.request_id = None
host = h.view("8.8.8.8")                    # request without x-request-id

h.request_id = "test-id-3"
host = h.view("8.8.8.8")                    # request with  x-request-id: test-id-3
```

This ux is definitely not ideal, but it makes the feature available quickly with minimal changes to the package interfaces. I figure this is tolerable for now since it's only meant for debugging.