### PR TITLE
feat(cli): inventory search and saved queries from cli

### DIFF
--- a/censys/asm/api.py
+++ b/censys/asm/api.py
@@ -110,3 +110,11 @@ class CensysAsmAPI(CensysAPIBase):
             args = {"cursor": res["nextCursor"]}
 
             yield from res["events"]
+
+    def get_workspace_id(self) -> str:
+        """Get the workspace ID.
+
+        Returns:
+            str: The workspace ID.
+        """
+        return self._get("/integrations/v1/account")["workspaceId"]

--- a/censys/asm/inventory.py
+++ b/censys/asm/inventory.py
@@ -37,8 +37,7 @@ class InventorySearch(CensysAsmAPI):
             )
         if page_size is None:
             page_size = 50
-        w: List[str] = []
-        w.append(self.get_workspace_id())
+        w: List[str] = [self.get_workspace_id()]
 
         args = {
             "workspaces": w,

--- a/censys/asm/inventory.py
+++ b/censys/asm/inventory.py
@@ -33,19 +33,18 @@ class InventorySearch(CensysAsmAPI):
             dict: Inventory search results.
         """
         if workspaces is None:
-            w: List[str] = [self.get_workspace_id()]
+            workspaces = [self.get_workspace_id()]
         else:
             warnings.warn(
                 "The field 'workspaces' is being deprecated. The workspace associated with `CENSYS-API-KEY` will be used automatically.",
                 category=DeprecationWarning,
                 stacklevel=2,
             )
-            w = workspaces
         if page_size is None:
             page_size = 50
 
         args = {
-            "workspaces": w,
+            "workspaces": workspaces,
             "pageSize": page_size,
         }
 

--- a/censys/asm/inventory.py
+++ b/censys/asm/inventory.py
@@ -1,6 +1,6 @@
 """Interact with the Censys Inventory Search API."""
-from typing import List, Optional
 import warnings
+from typing import List, Optional
 
 from .api import CensysAsmAPI
 

--- a/censys/asm/inventory.py
+++ b/censys/asm/inventory.py
@@ -1,5 +1,6 @@
 """Interact with the Censys Inventory Search API."""
 from typing import List, Optional
+import warnings
 
 from .api import CensysAsmAPI
 
@@ -31,13 +32,17 @@ class InventorySearch(CensysAsmAPI):
         Returns:
             dict: Inventory search results.
         """
-        if workspaces is not None:
-            print(
-                "The field 'workspaces' is being deprecated. The workspace associated with `CENSYS-API-KEY` will be used automatically."
+        if workspaces is None:
+            w: List[str] = [self.get_workspace_id()]
+        else:
+            warnings.warn(
+                "The field 'workspaces' is being deprecated. The workspace associated with `CENSYS-API-KEY` will be used automatically.",
+                category=DeprecationWarning,
+                stacklevel=2,
             )
+            w = workspaces
         if page_size is None:
             page_size = 50
-        w: List[str] = [self.get_workspace_id()]
 
         args = {
             "workspaces": w,

--- a/censys/asm/inventory.py
+++ b/censys/asm/inventory.py
@@ -11,7 +11,7 @@ class InventorySearch(CensysAsmAPI):
 
     def search(
         self,
-        workspaces: List[str],
+        workspaces: Optional[List[str]] = None,
         query: Optional[str] = None,
         page_size: Optional[int] = None,
         cursor: Optional[str] = None,
@@ -21,7 +21,7 @@ class InventorySearch(CensysAsmAPI):
         """Search inventory data.
 
         Args:
-            workspaces (List[str]): List of workspace IDs to search.
+            workspaces (List[str], optional): List of workspace IDs to search. Deprecated. The workspace associated with `CENSYS-API-KEY` will be used automatically.
             query (str, optional): Query string.
             page_size (int, optional): Number of results to return. Defaults to 50.
             cursor (str, optional): Cursor to start search from.
@@ -31,16 +31,28 @@ class InventorySearch(CensysAsmAPI):
         Returns:
             dict: Inventory search results.
         """
+        if workspaces is not None:
+            print(
+                "The field 'workspaces' is being deprecated. The workspace associated with `CENSYS-API-KEY` will be used automatically."
+            )
         if page_size is None:
             page_size = 50
+        w: List[str] = []
+        w.append(self.get_workspace_id())
+
         args = {
-            "workspaces": workspaces,
-            "query": query,
+            "workspaces": w,
             "pageSize": page_size,
-            "cursor": cursor,
-            "sort": sort,
-            "fields": fields,
         }
+
+        if query:
+            args["query"] = query
+        if cursor:
+            args["cursor"] = cursor
+        if sort:
+            args["sort"] = sort
+        if fields:
+            args["fields"] = fields
 
         return self._get(self.base_path, args=args)
 

--- a/censys/cli/commands/asm.py
+++ b/censys/cli/commands/asm.py
@@ -11,8 +11,8 @@ from xml.etree import ElementTree
 from rich.progress import Progress, TaskID
 from rich.prompt import Confirm, Prompt
 
-from censys.asm.saved_queries import SavedQueries
 from censys.asm.inventory import InventorySearch
+from censys.asm.saved_queries import SavedQueries
 from censys.asm.seeds import SEED_TYPES, Seeds
 from censys.cli.utils import console
 from censys.common.config import DEFAULT, get_config, write_config

--- a/censys/cli/commands/asm.py
+++ b/censys/cli/commands/asm.py
@@ -11,6 +11,7 @@ from xml.etree import ElementTree
 from rich.progress import Progress, TaskID
 from rich.prompt import Confirm, Prompt
 
+from censys.asm.api import CensysAsmAPI
 from censys.asm.inventory import InventorySearch
 from censys.asm.saved_queries import SavedQueries
 from censys.asm.seeds import SEED_TYPES, Seeds
@@ -40,6 +41,14 @@ def cli_asm_config(_: argparse.Namespace):  # pragma: no cover
         api_key_prompt = f"{api_key_prompt} [cyan]({redacted_api_key})[/cyan]"
 
     api_key = Prompt.ask(api_key_prompt, console=console) or api_key
+
+    try:
+        c = CensysAsmAPI(api_key)
+        w = c.get_workspace_id()
+        console.print(f"Successfully authenticated to workspace {w}")
+    except CensysUnauthorizedException:
+        console.print("Failed to authenticate")
+        sys.exit(1)
 
     if not api_key:
         console.print("Please enter valid credentials")

--- a/censys/cli/commands/asm.py
+++ b/censys/cli/commands/asm.py
@@ -550,10 +550,11 @@ def cli_execute_saved_query_by_name(args: argparse.Namespace):
     q = SavedQueries(args.api_key)
     # get query from name
     queries = q.get_saved_queries(args.query_name, 1, 1)
-    if not queries["results"]:
+    results = queries.get("results")
+    if not results:
         console.print("No saved query found with that name.")
         sys.exit(1)
-    query = queries["results"][0]["query"]
+    query = results[0]["query"]
 
     try:
         res = s.search(None, query, args.page_size, None, args.sort, args.fields)

--- a/censys/cli/commands/asm.py
+++ b/censys/cli/commands/asm.py
@@ -960,7 +960,7 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
     )
     search_parser.add_argument(
         "--workspaces",
-        help="Workspace IDs to search. Deprecated. The workspace associated with `CENSY-API-KEY` will be used automatically.",
+        help="Workspace IDs to search. Deprecated. The workspace associated with `CENSYS-API-KEY` will be used automatically.",
         type=str,
         required=False,
     )

--- a/censys/cli/commands/asm.py
+++ b/censys/cli/commands/asm.py
@@ -559,7 +559,7 @@ def cli_execute_saved_query_by_name(args: argparse.Namespace):
     try:
         res = s.search(None, query, args.page_size, None, args.sort, args.fields)
         console.print_json(json.dumps(res))
-    except (KeyError, CensysAsmException):
+    except CensysAsmException:
         console.print("Failed to execute saved query.")
         sys.exit(1)
 
@@ -604,7 +604,7 @@ def cli_search(args: argparse.Namespace):
             args.fields,
         )
         console.print_json(json.dumps(res))
-    except (KeyError, CensysAsmException):
+    except CensysAsmException:
         console.print("Failed to execute query.")
         sys.exit(1)
 

--- a/censys/cli/commands/asm.py
+++ b/censys/cli/commands/asm.py
@@ -581,7 +581,7 @@ def cli_execute_saved_query_by_id(args: argparse.Namespace):
     try:
         res = s.search(None, query, args.page_size, None, args.sort, args.fields)
         console.print_json(json.dumps(res))
-    except (KeyError, CensysAsmException):
+    except CensysAsmException:
         console.print("Failed to execute saved query.")
         sys.exit(1)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**tests**"]
 
-suppress_warnings = ["autosectionlabel.*"]
+suppress_warnings = ["autosectionlabel.usage-cli"]
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,8 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**tests**"]
 
+suppress_warnings = ["autosectionlabel.*"]
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==7.2.6
-sphinxcontrib-autoprogram==0.1.8
+sphinxcontrib-autoprogram==0.1.9
 sphinx-rtd-theme==1.3.0
 sphinx-prompt==1.8.0
 sphinx-tabs==3.4.1

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -341,3 +341,36 @@ Below we show an example of deleting a saved query by ID from the CLI.
 .. prompt:: bash
 
     censys asm delete-saved-query-by-id --query-id 'Some ID'
+
+``execute-saved-query-by-name``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+See CLI command :ref:`asm execute-saved-query-by-name<cli:censys asm execute-saved-query-by-name>` for detail documentation of parameters.
+
+Below we show an example of executing a saved query by name from the CLI.
+
+.. prompt:: bash
+
+    censys asm execute-saved-query-by-name --query-name 'Some query name'
+
+``execute-saved-query-by-id``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+See CLI command :ref:`asm execute-saved-query-by-id<cli:censys asm execute-saved-query-by-id>` for detail documentation of parameters.
+
+Below we show an example of executing a saved query by ID from the CLI.
+
+.. prompt:: bash
+
+    censys asm execute-saved-query-by-id --query-id 'Some query ID'
+
+``search``
+^^^^^^^^^^
+
+See CLI command :ref:`asm search<cli:censys asm search>` for detail documentation of parameters.
+
+Below we show an example of executing an inventory search query from the CLI.
+
+.. prompt:: bash
+
+    censys asm search --query 'Some query'

--- a/examples/asm/search.py
+++ b/examples/asm/search.py
@@ -5,7 +5,7 @@ from censys.asm import InventorySearch
 inventory_search = InventorySearch()
 
 # Delete the saved query by ID
-query = "query"
+query = "host.services.service_name: HTTP"
 res = inventory_search.search(query=query)
 
 print(res)

--- a/examples/asm/search.py
+++ b/examples/asm/search.py
@@ -1,0 +1,11 @@
+"""Execute a saved query by ID."""
+from censys.asm import InventorySearch
+
+# Create an instance of the SavedQueries class
+inventory_search = InventorySearch()
+
+# Delete the saved query by ID
+query = "query"
+res = inventory_search.search(query=query)
+
+print(res)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "censys"
-version = "2.2.12"
+version = "2.2.13"
 description = "An easy-to-use and lightweight API wrapper for Censys APIs (censys.io)."
 authors = ["Censys, Inc. <support@censys.io>"]
 license = "Apache-2.0"

--- a/tests/asm/test_api.py
+++ b/tests/asm/test_api.py
@@ -108,3 +108,17 @@ class CensysAsmAPITests(CensysTestCase):
         res = list(self.api._get_page(f"/{keyword}"))
         # Assertions
         assert res == page_json[keyword] + second_page
+
+    def test_get_workspace_id(self):
+        self.responses.add(
+            responses.GET,
+            f"{self.base_url}/integrations/v1/account",
+            status=200,
+            json={"workspaceId": "test-workspace-id"},
+        )
+
+        # Actual call
+        res = self.api.get_workspace_id()
+
+        # Assertions
+        assert res == "test-workspace-id"

--- a/tests/asm/test_inventory.py
+++ b/tests/asm/test_inventory.py
@@ -60,7 +60,7 @@ class InventoryTests(CensysTestCase):
                     "workspaces": ["1", "2"],
                     "query": "test",
                 },
-                "?workspaces=test-workspace-id&query=test&pageSize=50",
+                "?workspaces=1&workspaces=2&query=test&pageSize=50",
             ),
         ]
     )

--- a/tests/asm/test_inventory.py
+++ b/tests/asm/test_inventory.py
@@ -2,7 +2,7 @@ import responses
 from parameterized import parameterized
 
 from ..utils import CensysTestCase
-from .utils import BASE_URL
+from .utils import BASE_URL, WORKSPACE_ID
 from censys.asm.inventory import InventorySearch
 
 INVENTORY_BASE_PATH = f"{BASE_URL}/inventory/v1"
@@ -47,25 +47,27 @@ class InventoryTests(CensysTestCase):
         [
             (
                 {
-                    "workspaces": ["1", "2"],
                     "query": "test",
                     "page_size": 50,
                     "cursor": "test",
                     "sort": ["test"],
                     "fields": ["test"],
                 },
-                "?workspaces=1&workspaces=2&query=test&pageSize=50&cursor=test&sort=test&fields=test",
+                "?workspaces=test-workspace-id&query=test&pageSize=50&cursor=test&sort=test&fields=test",
             ),
             (
                 {
                     "workspaces": ["1", "2"],
                     "query": "test",
                 },
-                "?workspaces=1&workspaces=2&query=test&pageSize=50",
+                "?workspaces=test-workspace-id&query=test&pageSize=50",
             ),
         ]
     )
     def test_search(self, kwargs, params):
+        mock_request = self.mocker.patch("censys.asm.api.CensysAsmAPI.get_workspace_id")
+        mock_request.return_value = WORKSPACE_ID
+
         # Setup response
         self.responses.add(
             responses.GET,

--- a/tests/asm/utils.py
+++ b/tests/asm/utils.py
@@ -6,6 +6,7 @@ V1_URL = f"{BASE_URL}/v1"
 V2_URL = f"{BASE_URL}/v2"
 BETA_URL = f"{BASE_URL}/beta"
 INVENTORY_URL = f"{BASE_URL}/inventory"
+WORKSPACE_ID = "test-workspace-id"
 
 
 class MockResponse:


### PR DESCRIPTION
## Changes
Add capability to use ASM Inventory Search from the CLI with a query string, saved query ID, or saved query name

Examples:
`censys asm search --query 'domain: foo.com'`
`censys asm execute-saved-query-by-id --query-id 70000000-aaaa-4444-bbbb-eeeeeeeeeeee`
`censys asm-execute-saved-query-by-name --query-name 'my saved query'`

## Deprecation Notice
Previously, `workspaces` was a required field for the ASM `search()` function in the SDK. Going forward, the workspace ID associated with the API key being used will be automatically selected. `workspaces` is now an optional field in that function and will be removed altogether in the future.