### PR TITLE
fix: improve pagination for asm search

### DIFF
--- a/censys/asm/inventory.py
+++ b/censys/asm/inventory.py
@@ -68,7 +68,10 @@ class InventorySearch(CensysAsmAPI):
         resp = self._get(self.base_path, args=args)
         next_cursor = resp.get("nextCursor")
         hits.extend(resp.get("hits", []))
-        while next_cursor and (page == 0 or pages == -1 or page < pages):
+        # Fetch additional pages if next_cursor is available AND additional pages are requested
+        # Loop will exit if next_cursor is None or if the number of pages requested is reached
+        # Loop will exit if non-200 status code is returned
+        while next_cursor and (pages == -1 or page < pages):
             args["cursor"] = next_cursor
             resp = self._get(self.base_path, args=args)
             if "nextCursor" in resp:

--- a/censys/asm/inventory.py
+++ b/censys/asm/inventory.py
@@ -18,6 +18,7 @@ class InventorySearch(CensysAsmAPI):
         cursor: Optional[str] = None,
         sort: Optional[List[str]] = None,
         fields: Optional[List[str]] = None,
+        pages: Optional[int] = None,
     ) -> dict:
         """Search inventory data.
 
@@ -28,6 +29,7 @@ class InventorySearch(CensysAsmAPI):
             cursor (str, optional): Cursor to start search from.
             sort (List[str], optional): List of fields to sort by.
             fields (List[str], optional): List of fields to return.
+            pages (int, optional): Number of pages of results to return (when set to -1 returns all pages available).
 
         Returns:
             dict: Inventory search results.
@@ -43,6 +45,9 @@ class InventorySearch(CensysAsmAPI):
         if page_size is None:
             page_size = 50
 
+        if pages is None:
+            pages = 1
+
         args = {
             "workspaces": workspaces,
             "pageSize": page_size,
@@ -57,7 +62,24 @@ class InventorySearch(CensysAsmAPI):
         if fields:
             args["fields"] = fields
 
-        return self._get(self.base_path, args=args)
+        page = 0
+        next_cursor = None
+        hits = []
+        resp = self._get(self.base_path, args=args)
+        next_cursor = resp.get("nextCursor")
+        hits.extend(resp.get("hits", []))
+        while next_cursor and (page == 0 or pages == -1 or page < pages):
+            args["cursor"] = next_cursor
+            resp = self._get(self.base_path, args=args)
+            if "nextCursor" in resp:
+                next_cursor = resp.get("nextCursor")
+            else:
+                next_cursor = None
+            hits.extend(resp.get("hits", []))
+            page += 1
+
+        resp["hits"] = hits
+        return resp
 
     def aggregate(
         self,

--- a/censys/asm/inventory.py
+++ b/censys/asm/inventory.py
@@ -62,7 +62,7 @@ class InventorySearch(CensysAsmAPI):
         if fields:
             args["fields"] = fields
 
-        page = 0
+        page = 1
         next_cursor = None
         hits = []
         resp = self._get(self.base_path, args=args)

--- a/censys/cli/commands/asm.py
+++ b/censys/cli/commands/asm.py
@@ -557,7 +557,9 @@ def cli_execute_saved_query_by_name(args: argparse.Namespace):
     query = results[0]["query"]
 
     try:
-        res = s.search(None, query, args.page_size, None, args.sort, args.fields)
+        res = s.search(
+            None, query, args.page_size, None, args.sort, args.fields, args.pages
+        )
         console.print_json(json.dumps(res))
     except CensysAsmException:
         console.print("Failed to execute saved query.")
@@ -579,7 +581,9 @@ def cli_execute_saved_query_by_id(args: argparse.Namespace):
         console.print("No saved query found with that ID.")
         sys.exit(1)
     try:
-        res = s.search(None, query, args.page_size, None, args.sort, args.fields)
+        res = s.search(
+            None, query, args.page_size, None, args.sort, args.fields, args.pages
+        )
         console.print_json(json.dumps(res))
     except CensysAsmException:
         console.print("Failed to execute saved query.")
@@ -602,6 +606,7 @@ def cli_search(args: argparse.Namespace):
             args.cursor,
             args.sort,
             args.fields,
+            args.pages,
         )
         console.print_json(json.dumps(res))
     except CensysAsmException:
@@ -885,6 +890,12 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
         type=List[str],
         default=[],
     )
+    execute_saved_query_by_name_parser.add_argument(
+        "--pages",
+        help="Number of pages to return. Defaults to 1.",
+        type=int,
+        default=1,
+    )
     add_verbose(execute_saved_query_by_name_parser)
     execute_saved_query_by_name_parser.set_defaults(
         func=cli_execute_saved_query_by_name
@@ -919,6 +930,12 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
         help="Fields to include in results",
         type=List[str],
         default=[],
+    )
+    execute_saved_query_by_id_parser.add_argument(
+        "--pages",
+        help="Number of pages to return. Defaults to 1.",
+        type=int,
+        default=1,
     )
     add_verbose(execute_saved_query_by_id_parser)
     execute_saved_query_by_id_parser.set_defaults(func=cli_execute_saved_query_by_id)
@@ -964,6 +981,12 @@ def include(parent_parser: argparse._SubParsersAction, parents: dict):
         help="Workspace IDs to search. Deprecated. The workspace associated with `CENSYS-API-KEY` will be used automatically.",
         type=str,
         required=False,
+    )
+    search_parser.add_argument(
+        "--pages",
+        help="Number of pages to return. Defaults to 1.",
+        type=int,
+        default=1,
     )
     add_verbose(search_parser)
     search_parser.set_defaults(func=cli_search)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "censys"
-version = "2.2.13"
+version = "2.2.14"
 description = "An easy-to-use and lightweight API wrapper for Censys APIs (censys.io)."
 authors = ["Censys, Inc. <support@censys.io>"]
 license = "Apache-2.0"

--- a/tests/asm/test_inventory.py
+++ b/tests/asm/test_inventory.py
@@ -12,7 +12,7 @@ INVENTORY_FIELDS_PATH = f"{INVENTORY_BASE_PATH}/fields"
 
 TEST_INVENTORY_SEARCH_JSON = {
     "totalHits": 0,
-    "nextCursor": "string",
+    "nextCursor": "",
     "previousCursor": "string",
     "queryDurationMillis": 0,
     "hits": [{}],


### PR DESCRIPTION
## Changes
- Add `--pages` optional flag to `asm search`, `asm execute-saved-query-by-id`, and `asm execute-saved-query-by-name` to allow for easier pagination in the CLI. The default is 1. When set to -1, all pages will be returned.
- Bump version to 2.2.14