### PR TITLE
fix(risks): adds paging to risk_types API

### DIFF
--- a/censys/asm/risks.py
+++ b/censys/asm/risks.py
@@ -126,6 +126,8 @@ class Risks(CensysAsmAPI):
 
     def get_risk_types(
         self,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
         sort: Optional[List[str]] = None,
         include_events: Optional[bool] = None,
         accept: Optional[str] = None,
@@ -133,6 +135,8 @@ class Risks(CensysAsmAPI):
         """Retrieve risk types.
 
         Args:
+            limit (int, optional): Maximum number of results to return. Defaults to 1000.
+            page (int, optional): Page number to begin at when searching. Defaults to 1.
             sort (list): Optional; Sort by field(s).
             include_events (bool): Optional; Whether to include events.
             accept (str): Optional; Accept header.
@@ -140,7 +144,11 @@ class Risks(CensysAsmAPI):
         Returns:
             dict: Risk types result.
         """
-        args = {"sort": sort, "includeEvents": include_events}
+        args: Dict[str, Any] = {"sort": sort, "includeEvents": include_events}
+        if page:
+            args["page"] = page
+        if limit:
+            args["limit"] = limit
         return self._get(
             self.risk_types_path,
             args=args,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "censys"
-version = "2.2.15"
+version = "2.2.16"
 description = "An easy-to-use and lightweight API wrapper for Censys APIs (censys.io)."
 authors = ["Censys, Inc. <support@censys.io>"]
 license = "Apache-2.0"

--- a/tests/asm/test_risks.py
+++ b/tests/asm/test_risks.py
@@ -217,6 +217,8 @@ class RisksTests(CensysTestCase):
             ({"include_events": True}, "?includeEvents=True"),
             ({"include_events": False}, "?includeEvents=False"),
             ({"sort": ["severity", "type:asc"]}, "?sort=severity&sort=type:asc"),
+            ({"page": 1, "limit": 10000}, "?page=1&limit=10000"),
+            ({"page": 10}, "?page=10"),
         ]
     )
     def test_get_risk_types(self, kwargs, params):


### PR DESCRIPTION
 - Adds support for the paging API for the risk-types endpoint
 - Bumps version to 2.2.16