### PR TITLE
Adding cert-based proxy authentication to proxy configuration options

### DIFF
--- a/censys/common/base.py
+++ b/censys/common/base.py
@@ -100,6 +100,10 @@ class CensysAPIBase:
         if cookies:
             self._session.cookies.update(cookies)
         self.request_id = kwargs.get("request_id")
+        if kwargs.get('verify'):
+            self._session.verify = kwargs.get('verify')
+        if kwargs.get('cert'):
+            self._session.cert = kwargs.get('cert')
         self._session.headers.update(
             {
                 "accept": "application/json, */8",

--- a/censys/common/base.py
+++ b/censys/common/base.py
@@ -100,10 +100,10 @@ class CensysAPIBase:
         if cookies:
             self._session.cookies.update(cookies)
         self.request_id = kwargs.get("request_id")
-        if kwargs.get('verify'):
-            self._session.verify = kwargs.get('verify')
-        if kwargs.get('cert'):
-            self._session.cert = kwargs.get('cert')
+        if kwargs.get("verify"):
+            self._session.verify = kwargs.get("verify")
+        if kwargs.get("cert"):
+            self._session.cert = kwargs.get("cert")
         self._session.headers.update(
             {
                 "accept": "application/json, */8",

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -121,3 +121,13 @@ class CensysAPIBaseTests(CensysTestCase):
         base = CensysAPIBase(TEST_URL, cookies={"_ga": "GA"})
         # Assertions
         assert list(base._session.cookies.keys()) == ["_ga"]
+
+    def test_verify_and_cert(self):
+        # Mock/actual call
+        base = CensysAPIBase(
+            TEST_URL, 
+            cert=("/path/to/clientcert", "/path/to/clientkey"), 
+            verify="/path/to/cacert"
+        )
+        assert base._session.cert == ("/path/to/clientcert", "/path/to/clientkey")
+        assert base._session.verify == "/path/to/cacert"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -125,9 +125,9 @@ class CensysAPIBaseTests(CensysTestCase):
     def test_verify_and_cert(self):
         # Mock/actual call
         base = CensysAPIBase(
-            TEST_URL, 
-            cert=("/path/to/clientcert", "/path/to/clientkey"), 
-            verify="/path/to/cacert"
+            TEST_URL,
+            cert=("/path/to/clientcert", "/path/to/clientkey"),
+            verify="/path/to/cacert",
         )
         assert base._session.cert == ("/path/to/clientcert", "/path/to/clientkey")
         assert base._session.verify == "/path/to/cacert"


### PR DESCRIPTION
The requests library has the option to pass it both a `verify` and `cert` parameter.  This change just exposes the options when instantiating a session in CensysAPIBase.