### PR TITLE
fix(risks): perform URL path escaping on risk-types before using as input

### DIFF
--- a/censys/asm/risks.py
+++ b/censys/asm/risks.py
@@ -1,5 +1,6 @@
 """Interact with the Censys Risks API."""
 
+import urllib.parse
 from typing import Any, Dict, List, Optional
 
 from .api import CensysAsmAPI
@@ -168,8 +169,9 @@ class Risks(CensysAsmAPI):
         Returns:
             dict: Risk type result.
         """
+        escaped_risk_type = urllib.parse.quote(risk_type, safe="")
         args = {"includeEvents": include_events}
-        return self._get(f"{self.risk_types_path}/{risk_type}", args=args)
+        return self._get(f"{self.risk_types_path}/{escaped_risk_type}", args=args)
 
     def patch_risk_type(self, risk_type: str, data: dict) -> dict:
         """Patch a risk type.
@@ -181,4 +183,5 @@ class Risks(CensysAsmAPI):
         Returns:
             dict: Risk type result.
         """
-        return self._patch(f"{self.risk_types_path}/{risk_type}", data=data)
+        escaped_risk_type = urllib.parse.quote(risk_type, safe="")
+        return self._patch(f"{self.risk_types_path}/{escaped_risk_type}", data=data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "censys"
-version = "2.2.16"
+version = "2.2.17"
 description = "An easy-to-use and lightweight API wrapper for Censys APIs (censys.io)."
 authors = ["Censys, Inc. <support@censys.io>"]
 license = "Apache-2.0"

--- a/tests/asm/test_risks.py
+++ b/tests/asm/test_risks.py
@@ -1,3 +1,5 @@
+import urllib.parse
+
 import responses
 from parameterized import parameterized
 from responses import matchers
@@ -38,7 +40,8 @@ TEST_PATCH_RISK_INSTANCE_JSON = {
     "skips": 0,
     "userStatusChanges": 0,
 }
-TEST_RISK_TYPE = "service.authentication.http_weak_auth.http_weak_auth_encrypted"
+TEST_RISK_TYPE = "service.authentication.http_weak_auth/after-slash"
+ESCAPED_TEST_RISK_TYPE = urllib.parse.quote(TEST_RISK_TYPE, safe="")
 TEST_RISK_TYPE_JSON = {
     "config": "string",
     "contextType": "string",
@@ -236,14 +239,14 @@ class RisksTests(CensysTestCase):
 
     @parameterized.expand(
         [
-            ({"risk_type": TEST_RISK_TYPE}, TEST_RISK_TYPE),
+            ({"risk_type": TEST_RISK_TYPE}, ESCAPED_TEST_RISK_TYPE),
             (
                 {"risk_type": TEST_RISK_TYPE, "include_events": True},
-                TEST_RISK_TYPE + "?includeEvents=True",
+                ESCAPED_TEST_RISK_TYPE + "?includeEvents=True",
             ),
             (
                 {"risk_type": TEST_RISK_TYPE, "include_events": False},
-                TEST_RISK_TYPE + "?includeEvents=False",
+                ESCAPED_TEST_RISK_TYPE + "?includeEvents=False",
             ),
         ]
     )
@@ -270,7 +273,7 @@ class RisksTests(CensysTestCase):
         )
         self.responses.add(
             responses.PATCH,
-            V2_URL + f"/risk-types/{TEST_RISK_TYPE}",
+            V2_URL + f"/risk-types/{ESCAPED_TEST_RISK_TYPE}",
             status=200,
             json=TEST_PATCH_RISK_TYPE_JSON,
             match=[matchers.json_params_matcher(mock_patch)],


### PR DESCRIPTION
 - Updates the url handling for risk-types to escape the typeID in case it contains problematic elements
 - Bumps the version to 2.2.17