### PR TITLE
chore: drop Python 3.8, set minimum to 3.9

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: ["3.8", "3.10"]
+        python: ["3.9", "3.13"]
         poetry: ["2.2.1"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
@@ -36,20 +36,6 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install
-
-      #- name: Get all doc files that have changed
-        #id: changed_docs
-        #uses: tj-actions/changed-files@v41
-        #with:
-          #files: |
-            #docs
-
-      #- name: Build docs
-        #if: steps.changed_docs.outputs.any_changed == 'true' && startsWith(matrix.os, 'ubuntu') && startsWith(matrix.python, '3.10')
-        #working-directory: docs
-        #run: |
-          #poetry run pip install -r requirements.txt
-          #poetry run make html
 
       - name: Lint with flake8
         if: startsWith(matrix.os, 'ubuntu')

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Censys Python Library
 
 [![PyPI](https://img.shields.io/pypi/v/censys?color=orange&logo=pypi&logoColor=orange)](https://pypi.org/project/censys/)
-[![Python Version](https://img.shields.io/badge/python-3.8%2B-blue?logo=python)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.9%2B-blue?logo=python)](https://www.python.org/downloads/)
 [![Read the Docs (version)](https://img.shields.io/readthedocs/censys-python/latest?logo=read%20the%20docs)](https://censys-python.readthedocs.io/en/stable/?badge=stable)
 [![GitHub Discussions](https://img.shields.io/badge/GitHub-Discussions-brightgreen?logo=github)](https://github.com/censys/censys-python/discussions)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-organge.svg?logo=git&logoColor=organge)](http://makeapullrequest.com)
@@ -9,15 +9,15 @@
 
 > [!WARNING]
 > **DEPRECATION NOTICE**: The Censys Search v1 and v2 APIs will be deprecated soon. Please migrate to the new **Censys Platform**.
-> 
+>
 > - 📖 **New API Documentation**: [https://docs.censys.com/reference/get-started#/](https://docs.censys.com/reference/get-started#/)
 > - 📦 **New Python SDK**: Install with `pip install censys-platform` - [https://pypi.org/project/censys-platform/](https://pypi.org/project/censys-platform/)
 > - 🖥️ **New CLI Tool** (`cencli`): [https://docs.censys.com/docs/platform-cli](https://docs.censys.com/docs/platform-cli)
 >   - ⚠️ **If you plan to use the new CLI, you will need to uninstall this package's CLI first** as both use the `censys` command name
-> 
+>
 > The **Censys ASM APIs in this library are NOT deprecated** and will continue to be supported.
 
-An easy-to-use and lightweight API wrapper for Censys APIs ([censys.io](https://censys.io/)). Python 3.8+ is currently supported. This library has been tested on Python 3.8 and 3.x (Currently version 3.10).
+An easy-to-use and lightweight API wrapper for Censys APIs ([censys.io](https://censys.io/)). Python 3.9+ is currently supported. This library has been tested on Python 3.9 and 3.x (Currently version 3.13).
 
 ## Features
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,5 @@ sphinx==7.2.6
 sphinxcontrib-autoprogram==0.1.9
 sphinx-rtd-theme==3.0.2
 sphinx-prompt==1.8.0
-sphinx-tabs==3.4.1
+sphinx-tabs==3.5.0
 sphinx-copybutton==0.5.2

--- a/poetry.lock
+++ b/poetry.lock
@@ -1111,5 +1111,5 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.8,<4.0"
-content-hash = "0636bc5c37dffe33dfad83a11d4729bb86e2edfb1628d8801d5ce06fec8a52ed"
+python-versions = ">=3.9,<4.0"
+content-hash = "8f25c415d5aa41164129c96e6b2982ec1f2f0bddfaf41c8ccea95045bc044edf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,11 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
@@ -50,7 +51,7 @@ classifiers = [
 censys = "censys.cli:main"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 requests = ">=2.29.0"
 urllib3 = "<3.0.0"
 backoff = ">=2.0.0,<3.0.0"
@@ -83,7 +84,7 @@ mypy = "^1.5.1"
 types-requests = "^2.29.0.0"
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py39"]
 
 [tool.isort]
 profile = "black"
@@ -95,7 +96,7 @@ sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
 extend_skip = ["setup.py", "conf.py"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 files = ["censys"]
 namespace_packages = true
 explicit_package_bases = true

--- a/tests/cli/test_account.py
+++ b/tests/cli/test_account.py
@@ -30,8 +30,9 @@ class CensysCliAccountTest(CensysTestCase):
 
         temp_stdout = StringIO()
         # Actual call
-        with contextlib.redirect_stdout(temp_stdout), pytest.raises(
-            SystemExit, match="0"
+        with (
+            contextlib.redirect_stdout(temp_stdout),
+            pytest.raises(SystemExit, match="0"),
         ):
             cli_main()
 
@@ -61,8 +62,9 @@ class CensysCliAccountTest(CensysTestCase):
 
         temp_stdout = StringIO()
         # Actual call
-        with contextlib.redirect_stdout(temp_stdout), pytest.raises(
-            SystemExit, match="0"
+        with (
+            contextlib.redirect_stdout(temp_stdout),
+            pytest.raises(SystemExit, match="0"),
         ):
             cli_main()
 

--- a/tests/cli/test_asm.py
+++ b/tests/cli/test_asm.py
@@ -512,8 +512,9 @@ class CensysASMCliTest(CensysTestCase):
 
         # Actual call
         temp_stdout = StringIO()
-        with pytest.raises(SystemExit, match="1"), contextlib.redirect_stdout(
-            temp_stdout
+        with (
+            pytest.raises(SystemExit, match="1"),
+            contextlib.redirect_stdout(temp_stdout),
         ):
             cli_main()
 
@@ -559,8 +560,9 @@ class CensysASMCliTest(CensysTestCase):
 
         # Actual call
         temp_stdout = StringIO()
-        with pytest.raises(SystemExit, match="1"), contextlib.redirect_stdout(
-            temp_stdout
+        with (
+            pytest.raises(SystemExit, match="1"),
+            contextlib.redirect_stdout(temp_stdout),
         ):
             cli_main()
 
@@ -1132,8 +1134,9 @@ class CensysASMCliTest(CensysTestCase):
 
         # Actual call
         temp_stdout = StringIO()
-        with pytest.raises(SystemExit, match="0"), contextlib.redirect_stdout(
-            temp_stdout
+        with (
+            pytest.raises(SystemExit, match="0"),
+            contextlib.redirect_stdout(temp_stdout),
         ):
             cli_main()
 
@@ -2018,8 +2021,9 @@ class CensysASMCliTest(CensysTestCase):
 
         # Actual call
         temp_stdout = StringIO()
-        with pytest.raises(SystemExit, match="1"), contextlib.redirect_stdout(
-            temp_stdout
+        with (
+            pytest.raises(SystemExit, match="1"),
+            contextlib.redirect_stdout(temp_stdout),
         ):
             cli_main()
 
@@ -2069,8 +2073,9 @@ class CensysASMCliTest(CensysTestCase):
 
         # Actual call
         temp_stdout = StringIO()
-        with pytest.raises(SystemExit, match="1"), contextlib.redirect_stdout(
-            temp_stdout
+        with (
+            pytest.raises(SystemExit, match="1"),
+            contextlib.redirect_stdout(temp_stdout),
         ):
             cli_main()
 
@@ -2107,8 +2112,9 @@ class CensysASMCliTest(CensysTestCase):
 
         # Actual call
         temp_stdout = StringIO()
-        with pytest.raises(SystemExit, match="1"), contextlib.redirect_stdout(
-            temp_stdout
+        with (
+            pytest.raises(SystemExit, match="1"),
+            contextlib.redirect_stdout(temp_stdout),
         ):
             cli_main()
 
@@ -2176,8 +2182,9 @@ class CensysASMCliTest(CensysTestCase):
 
         # Actual call
         temp_stdout = StringIO()
-        with pytest.raises(SystemExit, match="1"), contextlib.redirect_stdout(
-            temp_stdout
+        with (
+            pytest.raises(SystemExit, match="1"),
+            contextlib.redirect_stdout(temp_stdout),
         ):
             cli_main()
 
@@ -2218,8 +2225,9 @@ class CensysASMCliTest(CensysTestCase):
 
         # Actual call
         temp_stdout = StringIO()
-        with pytest.raises(SystemExit, match="1"), contextlib.redirect_stdout(
-            temp_stdout
+        with (
+            pytest.raises(SystemExit, match="1"),
+            contextlib.redirect_stdout(temp_stdout),
         ):
             cli_main()
 
@@ -2247,8 +2255,9 @@ class CensysASMCliTest(CensysTestCase):
 
         # Actual call
         temp_stdout = StringIO()
-        with pytest.raises(SystemExit, match="1"), contextlib.redirect_stdout(
-            temp_stdout
+        with (
+            pytest.raises(SystemExit, match="1"),
+            contextlib.redirect_stdout(temp_stdout),
         ):
             cli_main()
 
@@ -2326,8 +2335,9 @@ class CensysASMCliTest(CensysTestCase):
 
         # Actual call
         temp_stdout = StringIO()
-        with pytest.raises(SystemExit, match="1"), contextlib.redirect_stdout(
-            temp_stdout
+        with (
+            pytest.raises(SystemExit, match="1"),
+            contextlib.redirect_stdout(temp_stdout),
         ):
             cli_main()
 


### PR DESCRIPTION
## Summary

- Bumps minimum Python from 3.8 to 3.9 — `virtualenv` dropped 3.8 support, which was breaking CI on every PR (including all open dependabot PRs)
- CI matrix now tests 3.9 (oldest) and 3.13 (newest) only, dropping the middle 3.10 job
- Updates classifiers to advertise 3.9–3.13 support
- Removes dead commented-out `tj-actions/changed-files` block from CI workflow
- Updates `poetry.lock` to reflect new constraint

## Test plan

- [ ] CI passes on 3.9 and 3.13
- [ ] Dependabot PRs (#715, #716, #717) can be rebased/re-run once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)