### PR TITLE
chore(deps): lift urllib3<3.0.0 upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "requests>=2.29.0",
-    "urllib3<3.0.0",
     "backoff>=2.0.0,<3.0.0",
     "rich>=10.16.2",
     "argcomplete>=2.0.0,<4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -92,8 +92,6 @@ dependencies = [
     { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "rich" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.dev-dependencies]
@@ -129,7 +127,6 @@ requires-dist = [
     { name = "backoff", specifier = ">=2.0.0,<3.0.0" },
     { name = "requests", specifier = ">=2.29.0" },
     { name = "rich", specifier = ">=10.16.2" },
-    { name = "urllib3", specifier = "<3.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- Removes the `urllib3<3.0.0` pin from `[project.dependencies]`
- urllib3 3.x has not been released; the cap was preventive and is now unnecessary noise
- Resolver continues to pick the latest 2.x automatically

## Test plan

- [x] 459 tests pass, 14 skipped, 100% coverage
- [x] `uv lock` resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)