### PR TITLE
chore(mypy): enable stricter type checking flags

### DIFF
--- a/censys/search/v2/certs.py
+++ b/censys/search/v2/certs.py
@@ -251,7 +251,7 @@ class CensysCerts(CensysSearchAPIv2):
             **kwargs,
         )
 
-    def search(  # type: ignore[override]
+    def search(
         self,
         query: str,
         per_page: int = 50,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,14 @@ python_version = "3.9"
 files = ["censys"]
 namespace_packages = true
 explicit_package_bases = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+strict_equality = true
+extra_checks = true
+no_implicit_reexport = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
 
 [[tool.mypy.overrides]]
 module = ["rich", "attr"]


### PR DESCRIPTION
## Summary

Enables 8 mypy flags that pass with zero code changes (plus one stale `# type: ignore` removal):

| Flag | Purpose |
|------|---------|
| `warn_unused_configs` | Catch dead mypy config |
| `warn_redundant_casts` | Remove unnecessary `cast()` calls |
| `warn_unused_ignores` | Remove stale `# type: ignore` comments |
| `strict_equality` | Catch always-true/false `==` comparisons |
| `extra_checks` | Additional correctness checks |
| `no_implicit_reexport` | Exports must be explicit |
| `check_untyped_defs` | Type-check bodies of untyped functions |
| `disallow_untyped_decorators` | Decorators must be typed |

Skipped `--disallow-incomplete-defs` and `--disallow-untyped-defs` (297 errors) — those are a future PR with annotation work.

## Test plan

- [x] `uv run mypy censys` — no issues in 47 source files
- [x] 459 tests pass, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)