### PR TITLE
chore(bump): bump version to 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "censys"
-version = "2.2.19"
+version = "2.3.0"
 description = "An easy-to-use and lightweight API wrapper for Censys APIs (censys.io)."
 authors = [{ name = "Censys, Inc.", email = "support@censys.io" }]
 license = "Apache-2.0"
@@ -38,7 +38,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "requests>=2.29.0",
+    "requests>=2.32.0",
     "backoff>=2.0.0,<3.0.0",
     "rich>=10.16.2",
     "argcomplete>=2.0.0,<4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -83,7 +83,7 @@ wheels = [
 
 [[package]]
 name = "censys"
-version = "2.2.19"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete", version = "3.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -125,14 +125,14 @@ docs = [
 requires-dist = [
     { name = "argcomplete", specifier = ">=2.0.0,<4.0.0" },
     { name = "backoff", specifier = ">=2.0.0,<3.0.0" },
-    { name = "requests", specifier = ">=2.29.0" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "rich", specifier = ">=10.16.2" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.5.1,<2" },
-    { name = "pytest", specifier = ">=7.3,<9" },
+    { name = "mypy", specifier = ">=1.5.1,<3" },
+    { name = "pytest", specifier = ">=7.3,<10" },
     { name = "pytest-cov", specifier = ">=4" },
     { name = "pytest-mock", specifier = ">=3.10.0,<4" },
     { name = "responses", specifier = ">=0.23.1" },


### PR DESCRIPTION
## Summary

- Version `2.2.19` → `2.3.0` (minor bump — drops Python 3.8 support)
- Tightens `requests` minimum from `>=2.29.0` to `>=2.32.0` (matches lowest version in the lock)

## Breaking changes

- Python 3.8 is no longer supported (`requires-python = ">=3.9"`)

## Test plan

- [x] 459 tests pass, 14 skipped, 100% coverage
- [x] `uv lock` resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)